### PR TITLE
Improved: make helper functions can import individually & improve a bit on tree-shaking

### DIFF
--- a/packages/frames.js/package.json
+++ b/packages/frames.js/package.json
@@ -19,6 +19,26 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./getFrame": {
+      "require": "./dist/getFrame.js",
+      "import": "./dist/getFrame.js",
+      "types": "./dist/getFrame.d.ts"
+    },
+    "./getFrameFlattened": {
+      "require": "./dist/getFrameFlattened.js",
+      "import": "./dist/getFrameFlattened.js",
+      "types": "./dist/getFrameFlattened.d.ts"
+    },
+    "./getFrameHtml": {
+      "require": "./dist/getFrameHtml.js",
+      "import": "./dist/getFrameHtml.js",
+      "types": "./dist/getFrameHtml.d.ts"
+    },
+    "./validateFrameMessage": {
+      "require": "./dist/validateFrameMessage.js",
+      "import": "./dist/validateFrameMessage.js",
+      "types": "./dist/validateFrameMessage.d.ts"
+    },
     "./next/client": {
       "require": "./dist/next/client.js",
       "import": "./dist/next/client.js",


### PR DESCRIPTION
## Change Summary

Currently, `import { Frame, getFrameFlattened } from "frames.js"` will include `farcaster/core` in final bundled file, thus, the file size is not optimized enough.

This PR proposes that we can import helper function individually so improve a bit on tree-shaking.

We can checkout the reproduce demo here: https://github.com/Leechael/framesjs-fix-demo

Result:

```
❯ l dist    
Permissions Size User     Date Modified Name
.rw-rw-r--   152 leechael  5 Feb 16:26  before.d.ts
.rw-rw-r--  5.9M leechael  5 Feb 16:26  before.js
.rw-rw-r--   161 leechael  5 Feb 16:26  getFrameFlattened.d.ts
.rw-rw-r--  1.5k leechael  5 Feb 16:26  getFrameFlattened.js
.rw-rw-r--  792k leechael  5 Feb 16:26  metafile-cjs.json
.rw-rw-r--   203 leechael  5 Feb 16:26  validateFrameMessage.d.ts
.rw-rw-r--  5.9M leechael  5 Feb 16:26  validateFrameMessage.js
```

We can use [esbuild analyze](https://esbuild.github.io/analyze/) and found out the root cause is`farcaster/core`.

<img width="1514" alt="image" src="https://github.com/framesjs/frames.js/assets/106123/f5f9ea87-fd65-4db5-8b57-d234eb0c0e4e">

Before we sure we can remove the dependency on `@farcaster/core`, this PR can help a bit when we only need `getFrameFlattened` and the type hinting from frames.js

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
