### PR TITLE
fix(core+debug): inputText can be undefined in frame action message

### DIFF
--- a/.changeset/eleven-bobcats-explode.md
+++ b/.changeset/eleven-bobcats-explode.md
@@ -1,0 +1,6 @@
+---
+"framesjs-starter": patch
+"frames.js": patch
+---
+
+fix: frame action message creation to not include inputText if inputText was not requested by the frame

--- a/examples/framesjs-starter/app/debug/components/frame-render.tsx
+++ b/examples/framesjs-starter/app/debug/components/frame-render.tsx
@@ -10,7 +10,10 @@ export function FrameRender({
   isLoggedIn: boolean;
   frame: Frame;
   url: string | null;
-  submitOption: (args: { buttonIndex: number; inputText: string }) => void;
+  submitOption: (args: {
+    buttonIndex: number;
+    inputText: string | undefined;
+  }) => void;
 }) {
   const [inputText, setInputText] = useState("");
 
@@ -49,7 +52,11 @@ export function FrameRender({
                   alert("Log in to use the frame buttons");
                   return;
                 }
-                return submitOption({ buttonIndex: index + 1, inputText });
+                return submitOption({
+                  buttonIndex: index + 1,
+                  inputText:
+                    frame.inputText !== undefined ? inputText : undefined,
+                });
               }}
               key={index}
             >

--- a/examples/framesjs-starter/app/debug/lib/farcaster.ts
+++ b/examples/framesjs-starter/app/debug/lib/farcaster.ts
@@ -4,6 +4,7 @@ import {
   makeFrameAction,
   FarcasterNetwork,
   Message,
+  FrameActionBody,
 } from "@farcaster/core";
 
 export async function createFrameActionMessageWithSignerKey(
@@ -18,8 +19,8 @@ export async function createFrameActionMessageWithSignerKey(
     fid: number;
     url: Uint8Array;
     buttonIndex: number;
-    inputText: Uint8Array;
-    castId: CastId | undefined;
+    inputText: Uint8Array | undefined;
+    castId: CastId;
   }
 ) {
   const signer = new NobleEd25519Signer(Buffer.from(signerKey.slice(2), "hex"));
@@ -30,12 +31,12 @@ export async function createFrameActionMessageWithSignerKey(
   };
 
   const message = await makeFrameAction(
-    {
+    FrameActionBody.create({
       url,
       buttonIndex,
       castId,
-      inputText,
-    },
+      inputText: inputText !== undefined ? Buffer.from(inputText) : undefined,
+    }),
     messageDataOptions,
     signer
   );

--- a/examples/framesjs-starter/app/debug/page.tsx
+++ b/examples/framesjs-starter/app/debug/page.tsx
@@ -39,7 +39,7 @@ export default function Page({
     inputText,
   }: {
     buttonIndex: number;
-    inputText: string;
+    inputText: string | undefined;
   }) => {
     if (!farcasterUser || !farcasterUser.fid || !frame) {
       return;
@@ -60,7 +60,7 @@ export default function Page({
         buttonIndex,
         castId,
         url: Buffer.from(frame.postUrl),
-        inputText: Buffer.from(inputText),
+        inputText: inputText !== undefined ? Buffer.from(inputText) : undefined,
       });
 
     if (!message) {


### PR DESCRIPTION
## Change Summary

Fixes types and frame action message creation to not include inputText if inputText was not requested by the frame.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
