### PR TITLE
fix: hubHttpUrl in options arg for getAddressForFid and validateFrameMessage

### DIFF
--- a/.changeset/cold-pumpkins-learn.md
+++ b/.changeset/cold-pumpkins-learn.md
@@ -1,0 +1,13 @@
+---
+"frames.js": minor
+---
+
+fix: Breaking change! `validateFrameMessage` & `getAddressForFid` now take an optional `hubHttpUrl` parameter to allow for custom hub URLs instead of env vars.
+
+If you were using `getAddressForFid`, you no longer need to include the second `hubClient` argument. Instead, you can optionally pass the `hubHttpUrl` in the second argument.
+
+```ts
+const address = getAddressForFid(fid);
+// or
+const address = getAddressForFid(fid, { hubHttpUrl: "..." });
+```

--- a/docs/pages/reference/js/getAddressForFid.mdx
+++ b/docs/pages/reference/js/getAddressForFid.mdx
@@ -1,24 +1,14 @@
 # getAddressForFid
 
-Returns the first verified address for a given `Farcaster` users `fid` if available, falling back to their account custodyAddress
+Returns the first verified address for a given Farcaster user's `fid` if available, falling back to their account `custodyAddress` if requested, otherwise returning `null`.
 
 ## Usage
 
 ```ts [example.ts]
 import { getAddressForFid } from "frames.js"
-import {
-  getInsecureHubRpcClient,
-  getSSLHubRpcClient,
-} from "@farcaster/hub-nodejs";
-
-export const hubClient =
-  process.env.HUB_USE_TLS && process.env.HUB_USE_TLS !== "false"
-    ? getSSLHubRpcClient(process.env.HUB_URL!)
-    : getInsecureHubRpcClient(process.env.HUB_URL!);
 
 const address = await getAddressForFid({
 	fid: 1214,
-	hubClient,
 	{ fallbackToCustodyAddress: true }
 });
 console.log(address) // 0xdAa83039ACA9a33b2e54bb2acC9f9c3A99357618

--- a/docs/pages/reference/js/types.mdx
+++ b/docs/pages/reference/js/types.mdx
@@ -1,8 +1,9 @@
 # Types exported from `frames.js`
 
 ## Example usage
+
 ```tsx
-import { Frame } from 'frames.js'
+import { Frame } from "frames.js";
 ```
 
 ## Reference
@@ -95,5 +96,11 @@ export type FrameActionPayload = {
     /** text input by the user into any input provided, "" if requested and no input, undefined if input not requested */
     inputText?: string;
   };
+};
+
+/** Options available in functions that make use of Hub queries */
+export type HubHttpUrlOptions = {
+  /** Hub HTTP REST API endpoint to use (default: https://nemes.farcaster.xyz:2281) */
+  hubHttpUrl?: string;
 };
 ```

--- a/packages/frames.js/src/getAddressForFid.test.ts
+++ b/packages/frames.js/src/getAddressForFid.test.ts
@@ -1,0 +1,24 @@
+import { getAddressForFid } from ".";
+
+describe("getAddressForFid", () => {
+  it("should get address for fid with connected address", async () => {
+    const fid = 1689;
+    const address = await getAddressForFid({ fid });
+    expect(address).not.toBe(null);
+  });
+
+  it("should return null for fid without connected address", async () => {
+    const fid = 1;
+    const address = await getAddressForFid({ fid });
+    expect(address).not.toBe(null);
+  });
+
+  it("should fall back to custody address if specified", async () => {
+    const fid = 1;
+    const address = await getAddressForFid({
+      fid,
+      options: { fallbackToCustodyAddress: true },
+    });
+    expect(address).not.toBe(null);
+  });
+});

--- a/packages/frames.js/src/getAddressForFid.ts
+++ b/packages/frames.js/src/getAddressForFid.ts
@@ -17,14 +17,13 @@ export async function getAddressForFid<
   fid: number;
   options?: Options;
 }): Promise<AddressReturnType<Options>> {
-  // Merge default options with user provided options
-  options = {
+  const optionsOrDefaults = {
     fallbackToCustodyAddress: options.fallbackToCustodyAddress ?? true,
     hubHttpUrl: options.hubHttpUrl ?? "https://nemes.farcaster.xyz:2281",
   };
 
   const verificationsResponse = await fetch(
-    `${options.hubHttpUrl}/v1/verificationsByFid?fid=${fid}`
+    `${optionsOrDefaults.hubHttpUrl}/v1/verificationsByFid?fid=${fid}`
   );
   const { messages } = await verificationsResponse.json();
   if (messages[0]) {
@@ -34,7 +33,7 @@ export async function getAddressForFid<
       },
     } = messages[0];
     return address;
-  } else if (options?.fallbackToCustodyAddress) {
+  } else if (optionsOrDefaults.fallbackToCustodyAddress) {
     const publicClient = createPublicClient({
       transport: http(),
       chain: optimism,

--- a/packages/frames.js/src/types.ts
+++ b/packages/frames.js/src/types.ts
@@ -86,3 +86,9 @@ export type FrameActionPayload = {
     inputText?: string;
   };
 };
+
+/** Options available in functions that make use of Hub queries */
+export type HubHttpUrlOptions = {
+  /** Hub HTTP REST API endpoint to use (default: https://nemes.farcaster.xyz:2281) */
+  hubHttpUrl?: string;
+};

--- a/packages/frames.js/src/validateFrameMessage.ts
+++ b/packages/frames.js/src/validateFrameMessage.ts
@@ -1,20 +1,26 @@
-import { FrameActionPayload, hexStringToUint8Array } from ".";
+import {
+  FrameActionPayload,
+  HubHttpUrlOptions,
+  hexStringToUint8Array,
+} from ".";
 import { FrameActionMessage, Message } from "@farcaster/core";
 
 /**
  * @returns a Promise that resolves with whether the message signature is valid, by querying a Farcaster hub, as well as the message itself
  */
-export async function validateFrameMessage(body: FrameActionPayload): Promise<{
+export async function validateFrameMessage(
+  body: FrameActionPayload,
+  options?: HubHttpUrlOptions
+): Promise<{
   isValid: boolean;
   message: FrameActionMessage | undefined;
 }> {
-  const hubBaseUrl =
-    process.env.FRAME_HUB_HTTP_URL ||
-    process.env.HUB_HTTP_URL ||
-    "https://nemes.farcaster.xyz:2281";
+  options = {
+    hubHttpUrl: options?.hubHttpUrl || "https://nemes.farcaster.xyz:2281",
+  };
 
   const validateMessageResponse = await fetch(
-    `${hubBaseUrl}/v1/validateMessage`,
+    `${options.hubHttpUrl}/v1/validateMessage`,
     {
       method: "POST",
       headers: {

--- a/packages/frames.js/src/validateFrameMessage.ts
+++ b/packages/frames.js/src/validateFrameMessage.ts
@@ -15,12 +15,12 @@ export async function validateFrameMessage(
   isValid: boolean;
   message: FrameActionMessage | undefined;
 }> {
-  options = {
+  const optionsOrDefaults: HubHttpUrlOptions = {
     hubHttpUrl: options?.hubHttpUrl || "https://nemes.farcaster.xyz:2281",
   };
 
   const validateMessageResponse = await fetch(
-    `${options.hubHttpUrl}/v1/validateMessage`,
+    `${optionsOrDefaults.hubHttpUrl}/v1/validateMessage`,
     {
       method: "POST",
       headers: {


### PR DESCRIPTION
## Change Summary

- Adds an optional second arg for `validateFrameMessage` to specify hub url, which falls back to nemes by default.
- Adds the same options to getAddressForFid and removes hubClient arg

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
