### PR TITLE
fix(debug): construct untrusted message data using original frame url

### DIFF
--- a/.changeset/cuddly-comics-brush.md
+++ b/.changeset/cuddly-comics-brush.md
@@ -1,0 +1,5 @@
+---
+"framesjs-starter": patch
+---
+
+fix(debug): untrusted data url now uses original frame url

--- a/examples/framesjs-starter/app/debug/page.tsx
+++ b/examples/framesjs-starter/app/debug/page.tsx
@@ -77,7 +77,7 @@ export default function Page({
         body: JSON.stringify({
           untrustedData: {
             fid: farcasterUser.fid,
-            url: frame.postUrl,
+            url: url,
             messageHash: `0x${Buffer.from(message.hash).toString("hex")}`,
             timestamp: message.data.timestamp,
             network: 1,


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->

- Updates the `submitOption` method to construct the `untrustedMessage` data's `url` field using the frame's original url instead of the post url.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
