### PR TITLE
Link to Frames Devs Channel

### DIFF
--- a/examples/framesjs-starter/README.md
+++ b/examples/framesjs-starter/README.md
@@ -20,7 +20,7 @@ This is a boilerplate repo to get started quickly with `frames.js`
 
 - [Frames.js Documentation](https://framesjs.org)
 - [Awesome frames](https://github.com/davidfurlong/awesome-frames?tab=readme-ov-file)
-- Join the [/frames-dev](https://warpcast.com/frames-dev) channel on Farcaster to ask questions
+- Join the [/frames-dev](https://warpcast.com/~/channel/frames-devs) channel on Farcaster to ask questions
 
 ## If you get stuck or have feedback, [Message @df please!](https://warpcast.com/df)
 


### PR DESCRIPTION
The current link doesn't bring me to the `frames-dev` channel.

## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [ ] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
