### PR TITLE
fix(debug): pass postUrl to frame-action endpoint

### DIFF
--- a/examples/framesjs-starter/app/debug/frame-action/route.ts
+++ b/examples/framesjs-starter/app/debug/frame-action/route.ts
@@ -5,10 +5,10 @@ export async function POST(req: NextRequest) {
   const body = await req.json();
   const isPostRedirect =
     req.nextUrl.searchParams.get("postType") === "post_redirect";
+  const postUrl = req.nextUrl.searchParams.get("postUrl")!;
 
   try {
-    const url = body.untrustedData.url;
-    const r = await fetch(url, {
+    const r = await fetch(postUrl, {
       method: "POST",
       headers: {
         Accept: "application/json",
@@ -29,7 +29,10 @@ export async function POST(req: NextRequest) {
 
     const htmlString = await r.text();
 
-    const { frame, errors } = getFrame({ htmlString, url });
+    const { frame, errors } = getFrame({
+      htmlString,
+      url: body.untrustedData.url,
+    });
 
     return Response.json({ frame, errors });
   } catch (err) {

--- a/examples/framesjs-starter/app/debug/page.tsx
+++ b/examples/framesjs-starter/app/debug/page.tsx
@@ -83,8 +83,13 @@ export default function Page({
       throw new Error("hub error");
     }
 
+    const searchParams = new URLSearchParams({
+      postType: button?.action || "post",
+      postUrl: currentFrame.frame.postUrl,
+    });
+
     const response = await fetch(
-      `/debug/frame-action?postType=${button?.action}`,
+      `/debug/frame-action?${searchParams.toString()}`,
       {
         method: "POST",
         headers: {


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Update debugger to pass the current frame's post url to the debugger's `frame-action` endpoint as it is not present in the action payload.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [ ] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
