### PR TITLE
feat: getFrameMessage

### DIFF
--- a/.changeset/honest-apes-work.md
+++ b/.changeset/honest-apes-work.md
@@ -1,0 +1,8 @@
+---
+"framesjs-starter": patch
+"frames.js": patch
+---
+
+feat: Add `getFrameMessage`, which parse frame action payloads and optionally fetches additional context from hubs.
+
+feat(debugger): Forward unmocked hub requests to an actual hub.

--- a/.changeset/slimy-wombats-hunt.md
+++ b/.changeset/slimy-wombats-hunt.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+Add a helper function to retrieve the user data for an FID

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -46,7 +46,11 @@ const reducer = (state, action) => ({ count: state.count + 1 });
 
 export default async function Home(props) {
   const previousFrame = getPreviousFrame(props.searchParams);
-  await validateActionSignature(previousFrame.postBody);
+  const frameMessage = await getFrameMessage(previousFrame.postBody);
+
+  if (frameMessage && !frameMessage?.isValid) {
+    throw new Error("Invalid frame payload");
+  }
   const [state, dispatch] = useFramesReducer(reducer, { count: 0 }, previousFrame);
 
   return (

--- a/docs/pages/reference/js/getAddressForFid.mdx
+++ b/docs/pages/reference/js/getAddressForFid.mdx
@@ -9,7 +9,7 @@ import { getAddressForFid } from "frames.js"
 
 const address = await getAddressForFid({
 	fid: 1214,
-	{ fallbackToCustodyAddress: true }
+	options: { fallbackToCustodyAddress: true }
 });
 console.log(address) // 0xdAa83039ACA9a33b2e54bb2acC9f9c3A99357618
 ```

--- a/docs/pages/reference/js/getFrameMessage.mdx
+++ b/docs/pages/reference/js/getFrameMessage.mdx
@@ -45,7 +45,13 @@ console.log(frameMessage);
   requesterFollowsCaster: false,
   likedCast: false,
   recastedCast: false,
-  requesterVerifiedAddresses: [ '0x8d25687829d6b85d9e0020b8c89e3ca24de20a89' ]
+  requesterVerifiedAddresses: [ '0x8d25687829d6b85d9e0020b8c89e3ca24de20a89' ],
+  requesterUserData: {
+    profileImage: 'https://lh3.googleusercontent.com/-S5cdhOpZtJ_Qzg9iPWELEsRTkIsZ7qGYmVlwEORgFB00WWAtZGefRnS4Bjcz5ah40WVOOWeYfU5pP9Eekikb3cLMW2mZQOMQHlWhg',
+    displayName: 'David Furlong',
+    username: 'df',
+    bio: 'Building open source software for /frames, to help Farcaster and decentralized social win'
+  }
 }
 **/
 ```

--- a/docs/pages/reference/js/getFrameMessage.mdx
+++ b/docs/pages/reference/js/getFrameMessage.mdx
@@ -1,0 +1,51 @@
+# getFrame
+
+Returns a `FrameActionData` object from the message trusted data.
+
+```ts
+type FrameActionData = {
+  buttonIndex: number;
+  requesterFid: number;
+  castId?: {
+    fid: number;
+    hash: `0x${string}`;
+  };
+  inputText?: string;
+};
+```
+
+If the `fetchHubContext` option is enabled, it will also validate the message and fetch additional context of type `FrameActionHubContext` from a Farcaster Hub.
+
+```ts
+type FrameActionHubContext = {
+  isValid: boolean;
+  requesterFollowsCaster: boolean;
+  casterFollowsRequester: boolean;
+  likedCast: boolean;
+  recastedCast: boolean;
+  requesterVerifiedAddresses: string[];
+};
+```
+
+## Usage
+
+```ts
+const frameMessage = await getFrameMessage(frameActionPayload, {
+  fetchHubContext: true,
+});
+console.log(frameMessage);
+/** 
+{
+  buttonIndex: 2,
+  castId: { fid: 1, hash: '0x0000000000000000000000000000000000000000' },
+  inputText: '',
+  requesterFid: 1689,
+  isValid: true,
+  casterFollowsRequester: false,
+  requesterFollowsCaster: false,
+  likedCast: false,
+  recastedCast: false,
+  requesterVerifiedAddresses: [ '0x8d25687829d6b85d9e0020b8c89e3ca24de20a89' ]
+}
+**/
+```

--- a/docs/pages/reference/js/getFrameMessage.mdx
+++ b/docs/pages/reference/js/getFrameMessage.mdx
@@ -1,4 +1,4 @@
-# getFrame
+# getFrameMessage
 
 Returns a `FrameActionData` object from the message trusted data.
 

--- a/docs/pages/reference/js/getUserDataForFid.mdx
+++ b/docs/pages/reference/js/getUserDataForFid.mdx
@@ -1,0 +1,19 @@
+# getUserDataForFid
+
+Returns the latest user data for a given Farcaster user's FID if available.
+
+## Usage
+
+```ts [example.ts]
+const userData = await getUserDataForFid({ fid });
+
+console.log(userData);
+/*
+{
+	profileImage: 'https://lh3.googleusercontent.com/-S5cdhOpZtJ_Qzg9iPWELEsRTkIsZ7qGYmVlwEORgFB00WWAtZGefRnS4Bjcz5ah40WVOOWeYfU5pP9Eekikb3cLMW2mZQOMQHlWhg',
+	displayName: 'David Furlong',
+	username: 'df',
+	bio: 'Building open source software for /frames, to help Farcaster and decentralized social win'
+}
+*/
+```

--- a/docs/pages/reference/js/types.mdx
+++ b/docs/pages/reference/js/types.mdx
@@ -119,4 +119,30 @@ export type HubHttpUrlOptions = {
   /** Hub HTTP REST API endpoint to use (default: https://nemes.farcaster.xyz:2281) */
   hubHttpUrl?: string;
 };
+
+/** Data extracted and parsed from the frame message body */
+export type FrameActionDataParsed = {
+  buttonIndex: number;
+  requesterFid: number;
+  castId?: {
+    fid: number;
+    hash: `0x${string}`;
+  };
+  inputText?: string;
+};
+
+/** Additional context for a frame message which requires communication with a Hub */
+export type FrameActionHubContext = {
+  isValid: boolean;
+  /** Whether the user that initiated the action (requester) follows the author of the cast */
+  requesterFollowsCaster: boolean;
+  /** Whether the author of the cast follows the requester */
+  casterFollowsRequester: boolean;
+  /** Whether the requester has liked the cast that the frame is attached to (false if no cast) */
+  likedCast: boolean;
+  /** Whether the requester has recasted the cast that the frame is attached to (false if no cast) */
+  recastedCast: boolean;
+  /** Verified eth addresses of the requester */
+  requesterVerifiedAddresses: string[];
+};
 ```

--- a/docs/pages/reference/js/types.mdx
+++ b/docs/pages/reference/js/types.mdx
@@ -84,6 +84,13 @@ export type AddressReturnType<
   ? `0x${string}`
   : `0x${string}` | null;
 
+export type UserDataReturnType = {
+  displayName?: string;
+  username?: string;
+  bio?: string;
+  profileImage?: string;
+} | null;
+
 /**
  * The body of valid `POST` requests triggered by Frame Buttons in other apps, when formatted as json, conforming to the Frames spec
  */

--- a/docs/vocs.config.tsx
+++ b/docs/vocs.config.tsx
@@ -35,6 +35,10 @@ const sidebar = [
             link: "/reference/js/getFrameHtml",
           },
           {
+            text: "getFrameMessage",
+            link: "/reference/js/getFrameMessage",
+          },
+          {
             text: "validateFrameMessage",
             link: "/reference/js/validateFrameMessage",
           },

--- a/docs/vocs.config.tsx
+++ b/docs/vocs.config.tsx
@@ -39,6 +39,10 @@ const sidebar = [
             link: "/reference/js/getFrameMessage",
           },
           {
+            text: "getUserDataForFid",
+            link: "/reference/js/getUserDataForFid",
+          },
+          {
             text: "validateFrameMessage",
             link: "/reference/js/validateFrameMessage",
           },

--- a/examples/framesjs-starter/app/debug/hub/[...hubPath]/route.ts
+++ b/examples/framesjs-starter/app/debug/hub/[...hubPath]/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest } from "next/server";
+
+function getHubUrl(url: string, hubPath: string[]) {
+  const newUrl = new URL(url);
+  newUrl.protocol = "https";
+  newUrl.hostname = "nemes.farcaster.xyz";
+  newUrl.port = "2281";
+  newUrl.pathname = hubPath.join("/");
+  return newUrl;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params: { hubPath } }: { params: { hubPath: string[] } }
+) {
+  console.warn(
+    `info: Mock hub: Forwarding message ${hubPath.join("/")} to a real hub`
+  );
+
+  const url = getHubUrl(request.url, hubPath);
+  const response = await fetch(url, {
+    headers: request.headers,
+  });
+
+  return response;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params: { hubPath } }: { params: { hubPath: string[] } }
+) {
+  const url = getHubUrl(request.url, hubPath);
+  const response = await fetch(url, {
+    method: "POST",
+    headers: request.headers,
+    body: request.body,
+  });
+  return response;
+}

--- a/examples/framesjs-starter/app/generate-image.tsx
+++ b/examples/framesjs-starter/app/generate-image.tsx
@@ -1,18 +1,14 @@
+import { FrameActionDataParsed } from "frames.js";
 import * as fs from "fs";
 import { join } from "path";
 import satori from "satori";
-import { FrameActionMessage } from "@farcaster/core";
 
 const interRegPath = join(process.cwd(), "public/Inter-Regular.ttf");
 let interReg = fs.readFileSync(interRegPath);
 
-export async function generateImage(validMessage: FrameActionMessage) {
-  const fid = validMessage?.data.fid;
-  const { buttonIndex, inputText: inputTextBytes } =
-    validMessage?.data.frameActionBody || {};
-  const inputText = inputTextBytes
-    ? Buffer.from(inputTextBytes).toString("utf-8")
-    : undefined;
+export async function generateImage(
+  actionPayload: FrameActionDataParsed | null
+) {
   const imageSvg = await satori(
     <div
       style={{
@@ -40,16 +36,20 @@ export async function generateImage(validMessage: FrameActionMessage) {
           marginTop: 24,
         }}
       >
-        {buttonIndex && fid && inputText ? (
+        {actionPayload ? (
           <div
             style={{
               display: "flex",
               flexDirection: "column",
             }}
           >
-            <div style={{ display: "flex" }}>Button index: {buttonIndex}</div>
-            <div style={{ display: "flex" }}>Fid: {fid}</div>
-            <div style={{ display: "flex" }}>{inputText}</div>
+            <div style={{ display: "flex" }}>
+              Button index: {actionPayload.buttonIndex}
+            </div>
+            <div style={{ display: "flex" }}>
+              Fid: {actionPayload.requesterFid}
+            </div>
+            <div style={{ display: "flex" }}>{actionPayload.inputText}</div>
           </div>
         ) : (
           <div

--- a/examples/framesjs-starter/app/page.tsx
+++ b/examples/framesjs-starter/app/page.tsx
@@ -8,6 +8,7 @@ import {
   getPreviousFrame,
   useFramesReducer,
   validateActionSignature,
+  getFrameMessage,
 } from "frames.js/next/server";
 import Link from "next/link";
 import { DEBUG_HUB_OPTIONS } from "./debug/constants";
@@ -52,6 +53,28 @@ export default async function Home({
   const image = await generateImage(validMessage!);
 
   console.log("State is:", state);
+
+  const frameMessage = await getFrameMessage(previousFrame.postBody, {
+    ...DEBUG_HUB_OPTIONS,
+    fetchHubContext: true,
+  });
+
+  if (frameMessage) {
+    const {
+      isValid,
+      buttonIndex,
+      inputText,
+      castId,
+      requesterFid,
+      casterFollowsRequester,
+      requesterFollowsCaster,
+      likedCast,
+      recastedCast,
+      requesterVerifiedAddresses,
+    } = frameMessage;
+
+    console.log(frameMessage);
+  }
 
   // then, when done, return next frame
   return (

--- a/examples/framesjs-starter/app/page.tsx
+++ b/examples/framesjs-starter/app/page.tsx
@@ -37,10 +37,14 @@ export default async function Home({
 }: NextServerPageProps) {
   const previousFrame = getPreviousFrame<State>(searchParams);
 
-  const validMessage = await validateActionSignature(
-    previousFrame.postBody,
-    DEBUG_HUB_OPTIONS
-  );
+  const frameMessage = await getFrameMessage(previousFrame.postBody, {
+    ...DEBUG_HUB_OPTIONS,
+    fetchHubContext: true,
+  });
+
+  if (frameMessage && !frameMessage?.isValid) {
+    throw new Error("Invalid frame payload");
+  }
 
   const [state, dispatch] = useFramesReducer<State>(
     reducer,
@@ -50,14 +54,9 @@ export default async function Home({
 
   // Here: do a server side side effect either sync or async (using await), such as minting an NFT if you want.
   // example: load the users credentials & check they have an NFT
-  const image = await generateImage(validMessage!);
+  const image = await generateImage(frameMessage);
 
   console.log("State is:", state);
-
-  const frameMessage = await getFrameMessage(previousFrame.postBody, {
-    ...DEBUG_HUB_OPTIONS,
-    fetchHubContext: true,
-  });
 
   if (frameMessage) {
     const {
@@ -85,7 +84,7 @@ export default async function Home({
         state={state}
         previousFrame={previousFrame}
       >
-        <FrameImage src="https://framesjs.org/og.png" />
+        {<FrameImage src="https://framesjs.org/og.png" />}
         {/* <FrameImage
           src={`data:image/svg+xml,${encodeURIComponent(imageSvg)}`}
         /> */}

--- a/examples/framesjs-starter/app/page.tsx
+++ b/examples/framesjs-starter/app/page.tsx
@@ -70,6 +70,7 @@ export default async function Home({
       likedCast,
       recastedCast,
       requesterVerifiedAddresses,
+      requesterUserData,
     } = frameMessage;
 
     console.log(frameMessage);

--- a/examples/framesjs-starter/app/page.tsx
+++ b/examples/framesjs-starter/app/page.tsx
@@ -84,10 +84,7 @@ export default async function Home({
         state={state}
         previousFrame={previousFrame}
       >
-        {<FrameImage src="https://framesjs.org/og.png" />}
-        {/* <FrameImage
-          src={`data:image/svg+xml,${encodeURIComponent(imageSvg)}`}
-        /> */}
+        <FrameImage src="https://framesjs.org/og.png" />
         <FrameInput text="put some text here" />
         <FrameButton onClick={dispatch}>
           {state?.active === "1" ? "Active" : "Inactive"}

--- a/examples/framesjs-starter/package.json
+++ b/examples/framesjs-starter/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@noble/ed25519": "^2.0.0",
-    "frames.js": "*",
+    "frames.js": "^0.1.0",
     "next": "14.1.0",
     "qrcode.react": "^3.1.0",
     "react": "^18",

--- a/examples/framesjs-starter/package.json
+++ b/examples/framesjs-starter/package.json
@@ -18,6 +18,9 @@
     "satori": "^0.10.13",
     "swr": "^2.2.4"
   },
+  "engines": {
+    "node": ">=18.17.0"
+  },
   "devDependencies": {
     "@types/node": "^20",
     "@types/react": "^18",

--- a/examples/utils-starter/package.json
+++ b/examples/utils-starter/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint . --max-warnings 0"
   },
   "dependencies": {
-    "frames.js": "*",
+    "frames.js": "^0.1.0",
     "next": "^14.0.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/packages/frames.js/package.json
+++ b/packages/frames.js/package.json
@@ -34,6 +34,11 @@
       "import": "./dist/getFrameHtml.js",
       "types": "./dist/getFrameHtml.d.ts"
     },
+    "./getFrameMessage": {
+      "require": "./dist/getFrameMessage.js",
+      "import": "./dist/getFrameMessage.js",
+      "types": "./dist/getFrameMessage.d.ts"
+    },
     "./validateFrameMessage": {
       "require": "./dist/validateFrameMessage.js",
       "import": "./dist/validateFrameMessage.js",

--- a/packages/frames.js/package.json
+++ b/packages/frames.js/package.json
@@ -19,6 +19,26 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./getFrame": {
+      "require": "./dist/getFrame.js",
+      "import": "./dist/getFrame.js",
+      "types": "./dist/getFrame.d.ts"
+    },
+    "./getFrameFlattened": {
+      "require": "./dist/getFrameFlattened.js",
+      "import": "./dist/getFrameFlattened.js",
+      "types": "./dist/getFrameFlattened.d.ts"
+    },
+    "./getFrameHtml": {
+      "require": "./dist/getFrameHtml.js",
+      "import": "./dist/getFrameHtml.js",
+      "types": "./dist/getFrameHtml.d.ts"
+    },
+    "./validateFrameMessage": {
+      "require": "./dist/validateFrameMessage.js",
+      "import": "./dist/validateFrameMessage.js",
+      "types": "./dist/validateFrameMessage.d.ts"
+    },
     "./next/client": {
       "require": "./dist/next/client.js",
       "import": "./dist/next/client.js",

--- a/packages/frames.js/src/getFrameMessage.ts
+++ b/packages/frames.js/src/getFrameMessage.ts
@@ -5,6 +5,7 @@ import {
   FrameActionPayload,
   HubHttpUrlOptions,
   getAddressForFid,
+  getUserDataForFid,
   normalizeCastId,
   validateFrameMessage,
 } from ".";
@@ -60,6 +61,7 @@ export async function getFrameMessage<T extends GetFrameMessageOptions>(
       likedCast,
       recastedCast,
       requesterVerifiedAddresses,
+      requesterUserData,
     ] = await Promise.all([
       validateFrameMessage(payload, {
         hubHttpUrl: optionsOrDefaults.hubHttpUrl,
@@ -82,6 +84,12 @@ export async function getFrameMessage<T extends GetFrameMessageOptions>(
           hubHttpUrl: optionsOrDefaults.hubHttpUrl,
         },
       }),
+      getUserDataForFid({
+        fid: requesterFid,
+        options: {
+          hubHttpUrl: optionsOrDefaults.hubHttpUrl,
+        },
+      }),
     ]);
 
     // Perform actions to fetch the HubFrameContext and then return the combined result
@@ -94,6 +102,7 @@ export async function getFrameMessage<T extends GetFrameMessageOptions>(
       requesterVerifiedAddresses: requesterVerifiedAddresses
         ? [requesterVerifiedAddresses]
         : [],
+      requesterUserData,
     };
     return { ...parsedData, ...hubContext } as FrameMessageReturnType<T>;
   } else {

--- a/packages/frames.js/src/getFrameMessage.ts
+++ b/packages/frames.js/src/getFrameMessage.ts
@@ -1,0 +1,99 @@
+import { FrameActionMessage, Message } from "@farcaster/core";
+import {
+  FrameActionDataParsed,
+  FrameActionHubContext,
+  FrameActionPayload,
+  HubHttpUrlOptions,
+  getAddressForFid,
+  normalizeCastId,
+  validateFrameMessage,
+} from ".";
+
+export type GetFrameMessageOptions = {
+  fetchHubContext?: boolean;
+} & HubHttpUrlOptions;
+
+export type FrameMessageReturnType<T extends GetFrameMessageOptions> =
+  T["fetchHubContext"] extends true
+    ? FrameActionDataParsed & FrameActionHubContext
+    : FrameActionDataParsed;
+
+export async function getFrameMessage<T extends GetFrameMessageOptions>(
+  payload: FrameActionPayload,
+  options?: T
+): Promise<FrameMessageReturnType<T>> {
+  const optionsOrDefaults = {
+    fetchHubContext: options?.fetchHubContext ?? false,
+    hubHttpUrl: options?.hubHttpUrl || "https://nemes.farcaster.xyz:2281",
+  };
+
+  const decodedMessage = Message.decode(
+    Buffer.from(payload.trustedData.messageBytes, "hex")
+  ) as FrameActionMessage;
+
+  const { buttonIndex, inputText: inputTextBytes } =
+    decodedMessage.data.frameActionBody || {};
+  const inputText = inputTextBytes
+    ? Buffer.from(inputTextBytes).toString("utf-8")
+    : undefined;
+
+  const requesterFid = decodedMessage.data.fid;
+  const castId = decodedMessage.data.frameActionBody.castId
+    ? normalizeCastId(decodedMessage.data.frameActionBody.castId)
+    : undefined;
+
+  const parsedData: FrameActionDataParsed = {
+    buttonIndex,
+    castId,
+    inputText,
+    requesterFid,
+  };
+
+  if (optionsOrDefaults?.fetchHubContext) {
+    const [
+      validationResult,
+      requesterFollowsCaster,
+      casterFollowsRequester,
+      likedCast,
+      recastedCast,
+      requesterVerifiedAddresses,
+    ] = await Promise.all([
+      validateFrameMessage(payload, {
+        hubHttpUrl: optionsOrDefaults.hubHttpUrl,
+      }),
+      fetch(
+        `${optionsOrDefaults.hubHttpUrl}/v1/linkById?fid=${requesterFid}&target_fid=${castId?.fid}&link_type=follow`
+      ).then((res) => res.ok || requesterFid === castId?.fid),
+      fetch(
+        `${optionsOrDefaults.hubHttpUrl}/v1/linkById?fid=${castId?.fid}&target_fid=${requesterFid}&link_type=follow`
+      ).then((res) => res.ok || requesterFid === castId?.fid),
+      fetch(
+        `${optionsOrDefaults.hubHttpUrl}/v1/reactionById?fid=${requesterFid}&reaction_type=1&target_fid=${castId?.fid}&target_hash=${castId?.hash}`
+      ).then((res) => res.ok),
+      fetch(
+        `${optionsOrDefaults.hubHttpUrl}/v1/reactionById?fid=${requesterFid}&reaction_type=2&target_fid=${castId?.fid}&target_hash=${castId?.hash}`
+      ).then((res) => res.ok),
+      getAddressForFid({
+        fid: requesterFid,
+        options: {
+          hubHttpUrl: optionsOrDefaults.hubHttpUrl,
+        },
+      }),
+    ]);
+
+    // Perform actions to fetch the HubFrameContext and then return the combined result
+    const hubContext: FrameActionHubContext = {
+      isValid: validationResult.isValid,
+      casterFollowsRequester: casterFollowsRequester,
+      requesterFollowsCaster: requesterFollowsCaster,
+      likedCast,
+      recastedCast,
+      requesterVerifiedAddresses: requesterVerifiedAddresses
+        ? [requesterVerifiedAddresses]
+        : [],
+    };
+    return { ...parsedData, ...hubContext } as FrameMessageReturnType<T>;
+  } else {
+    return parsedData as FrameMessageReturnType<T>;
+  }
+}

--- a/packages/frames.js/src/getFrameMessage.ts
+++ b/packages/frames.js/src/getFrameMessage.ts
@@ -18,12 +18,15 @@ export type FrameMessageReturnType<T extends GetFrameMessageOptions> =
     ? FrameActionDataParsed & FrameActionHubContext
     : FrameActionDataParsed;
 
+/** Returns a `FrameActionData` object from the message trusted data. (e.g. button index, input text). The `fetchHubContext` option (default: true) determines whether to validate and fetch other metadata from hubs.
+ * If `isValid` is false, the message should not be trusted.
+ */
 export async function getFrameMessage<T extends GetFrameMessageOptions>(
   payload: FrameActionPayload,
   options?: T
 ): Promise<FrameMessageReturnType<T>> {
   const optionsOrDefaults = {
-    fetchHubContext: options?.fetchHubContext ?? false,
+    fetchHubContext: options?.fetchHubContext ?? true,
     hubHttpUrl: options?.hubHttpUrl || "https://nemes.farcaster.xyz:2281",
   };
 

--- a/packages/frames.js/src/getUserDataForFid.test.ts
+++ b/packages/frames.js/src/getUserDataForFid.test.ts
@@ -1,0 +1,18 @@
+import { getUserDataForFid } from ".";
+
+describe("getUserDataForFid", () => {
+  it("should get latest user data for fid", async () => {
+    const fid = 1214;
+    const userData = await getUserDataForFid({ fid });
+
+    console.log(userData);
+
+    expect(userData).not.toBe(null);
+  });
+
+  it("should return null for invalid fid", async () => {
+    const fid = 1000000000000;
+    const userData = await getUserDataForFid({ fid });
+    expect(userData).toBe(null);
+  });
+});

--- a/packages/frames.js/src/getUserDataForFid.ts
+++ b/packages/frames.js/src/getUserDataForFid.ts
@@ -1,0 +1,55 @@
+import { MessageType, UserDataType, Message } from "@farcaster/core";
+import { HubHttpUrlOptions, UserDataReturnType } from "./types";
+
+/**
+ * Returns the latest user data for a given Farcaster users Fid if available.
+ */
+export async function getUserDataForFid<
+  Options extends HubHttpUrlOptions | undefined,
+>({
+  fid,
+  options = {},
+}: {
+  /** the user's Farcaster fid` */
+  fid: number;
+  options?: Options;
+}): Promise<UserDataReturnType> {
+  const optionsOrDefaults = {
+    hubHttpUrl: options.hubHttpUrl ?? "https://nemes.farcaster.xyz:2281",
+  };
+
+  const userDataResponse = await fetch(
+    `${optionsOrDefaults.hubHttpUrl}/v1/userDataByFid?fid=${fid}`
+  );
+
+  const { messages } = await userDataResponse.json();
+
+  if (messages && messages.length > 0) {
+    const valuesByType = messages.reduce((acc: any, messageJson: any) => {
+      const message = Message.fromJSON(messageJson);
+
+      if (message.data?.type !== MessageType.USER_DATA_ADD) {
+        return;
+      }
+
+      const timestamp = message.data.timestamp;
+      const { type, value } = message.data.userDataBody!;
+
+      if (!acc[type]) {
+        acc[type] = { value, timestamp };
+      } else if (message.data.timestamp > acc[type].timestamp) {
+        acc[type] = { value, timestamp };
+      }
+      return acc;
+    }, {});
+
+    return {
+      profileImage: valuesByType[UserDataType.PFP]?.value,
+      displayName: valuesByType[UserDataType.DISPLAY]?.value,
+      username: valuesByType[UserDataType.USERNAME]?.value,
+      bio: valuesByType[UserDataType.BIO]?.value,
+    };
+  } else {
+    return null;
+  }
+}

--- a/packages/frames.js/src/index.ts
+++ b/packages/frames.js/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./getAddressForFid";
+export * from "./getUserDataForFid";
 export * from "./getFrame";
 export * from "./getFrameHtml";
 export * from "./getFrameFlattened";

--- a/packages/frames.js/src/index.ts
+++ b/packages/frames.js/src/index.ts
@@ -5,3 +5,4 @@ export * from "./getFrameFlattened";
 export * from "./types";
 export * from "./utils";
 export * from "./validateFrameMessage";
+export * from "./getFrameMessage";

--- a/packages/frames.js/src/next/server.tsx
+++ b/packages/frames.js/src/next/server.tsx
@@ -2,7 +2,13 @@ import { FrameActionMessage } from "@farcaster/core";
 import { headers } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 import React from "react";
-import { getByteLength, validateFrameMessage } from "..";
+import {
+  FrameMessageReturnType,
+  GetFrameMessageOptions,
+  getByteLength,
+  validateFrameMessage,
+  getFrameMessage as _getFrameMessage,
+} from "..";
 import { ActionIndex, FrameActionPayload, HubHttpUrlOptions } from "../types";
 // Todo: this isn't respecting the use client directive
 import { FrameButtonRedirectUI, FrameButtonUI } from "./client";
@@ -46,6 +52,26 @@ export async function validateActionSignature(
   }
 
   return message;
+}
+
+/** Convenience wrapper around `framesjs.getFrameMessage` that accepts a null for payload body */
+export async function getFrameMessage<T extends GetFrameMessageOptions>(
+  frameActionPayload: FrameActionPayload | null,
+  options?: T
+): Promise<FrameMessageReturnType<T> | null> {
+  if (!frameActionPayload) {
+    console.log("no frameActionPayload");
+    // no payload means no action
+    return null;
+  }
+
+  const result = await _getFrameMessage(frameActionPayload, options);
+
+  if (!result) {
+    throw new Error("frames.js: something went wrong getting frame message");
+  }
+
+  return result;
 }
 
 /** deserializes a `PreviousFrame` from url searchParams, fetching headers automatically from nextjs, @returns PreviousFrame */

--- a/packages/frames.js/src/next/server.tsx
+++ b/packages/frames.js/src/next/server.tsx
@@ -54,7 +54,10 @@ export async function validateActionSignature(
   return message;
 }
 
-/** Convenience wrapper around `framesjs.getFrameMessage` that accepts a null for payload body */
+/** Convenience wrapper around `framesjs.getFrameMessage` that accepts a null for payload body.
+ * Returns a `FrameActionData` object from the message trusted data. (e.g. button index, input text). The `fetchHubContext` option (default: true) determines whether to validate and fetch other metadata from hubs.
+ * If `isValid` is false, the message should not be trusted.
+ */
 export async function getFrameMessage<T extends GetFrameMessageOptions>(
   frameActionPayload: FrameActionPayload | null,
   options?: T

--- a/packages/frames.js/src/types.ts
+++ b/packages/frames.js/src/types.ts
@@ -73,6 +73,13 @@ export type AddressReturnType<
   ? `0x${string}`
   : `0x${string}` | null;
 
+export type UserDataReturnType = {
+  displayName?: string;
+  username?: string;
+  bio?: string;
+  profileImage?: string;
+} | null;
+
 /**
  * The body of valid `POST` requests triggered by Frame Buttons in other apps, when formatted as json, conforming to the Frames spec
  */

--- a/packages/frames.js/src/types.ts
+++ b/packages/frames.js/src/types.ts
@@ -140,4 +140,6 @@ export type FrameActionHubContext = {
   recastedCast: boolean;
   /** Verified eth addresses of the requester */
   requesterVerifiedAddresses: string[];
+  /** User data of the requester */
+  requesterUserData: UserDataReturnType;
 };

--- a/packages/frames.js/src/types.ts
+++ b/packages/frames.js/src/types.ts
@@ -108,3 +108,29 @@ export type HubHttpUrlOptions = {
   /** Hub HTTP REST API endpoint to use (default: https://nemes.farcaster.xyz:2281) */
   hubHttpUrl?: string;
 };
+
+/** Data extracted and parsed from the frame message body */
+export type FrameActionDataParsed = {
+  buttonIndex: number;
+  requesterFid: number;
+  castId?: {
+    fid: number;
+    hash: `0x${string}`;
+  };
+  inputText?: string;
+};
+
+/** Additional context for a frame message which requires communication with a Hub */
+export type FrameActionHubContext = {
+  isValid: boolean;
+  /** Whether the user that initiated the action (requester) follows the author of the cast */
+  requesterFollowsCaster: boolean;
+  /** Whether the author of the cast follows the requester */
+  casterFollowsRequester: boolean;
+  /** Whether the requester has liked the cast that the frame is attached to (false if no cast) */
+  likedCast: boolean;
+  /** Whether the requester has recasted the cast that the frame is attached to (false if no cast) */
+  recastedCast: boolean;
+  /** Verified eth addresses of the requester */
+  requesterVerifiedAddresses: string[];
+};


### PR DESCRIPTION
## Change Summary

- Add `getFrameMessage`, which parse frame action payloads and optionally fetches additional context from hubs.
- Forward unmocked hub requests to an actual hub.

Closes #21 

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
