### PR TITLE
feat: provide example of encoding svg image

### DIFF
--- a/examples/framesjs-starter/app/generate-image.tsx
+++ b/examples/framesjs-starter/app/generate-image.tsx
@@ -8,7 +8,7 @@ let interReg = fs.readFileSync(interRegPath);
 
 export async function generateImage(
   actionPayload: FrameActionDataParsed | null
-) {
+): Promise<string> {
   const imageSvg = await satori(
     <div
       style={{

--- a/examples/framesjs-starter/app/page.tsx
+++ b/examples/framesjs-starter/app/page.tsx
@@ -54,7 +54,9 @@ export default async function Home({
 
   // Here: do a server side side effect either sync or async (using await), such as minting an NFT if you want.
   // example: load the users credentials & check they have an NFT
-  const image = await generateImage(frameMessage);
+  const imageSVG = await generateImage(frameMessage);
+  // Generated image can be supplied directly to <FrameImage src={imageEncoded} /> 
+  const imageEncoded = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(imageSVG)}`;
 
   console.log("State is:", state);
 


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. --> 
Adjusts the `framejs-starter` example to include an encoded value of the rendered SVG from `generateImage` which can be used for the `FrameImage` component.

This allows the user to plugin the variable directly to the boilerplate code.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [ ] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
