### PR TITLE
feat: http request options

### DIFF
--- a/.changeset/selfish-avocados-burn.md
+++ b/.changeset/selfish-avocados-burn.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+feat: throw clearer error when hub url is specified without protocol (e.g. https://)

--- a/.changeset/seven-teachers-bake.md
+++ b/.changeset/seven-teachers-bake.md
@@ -1,6 +1,0 @@
----
-"frames.js": minor
-"framesjs-starter": patch
----
-
-feat: JSX-based frame image rendering

--- a/.changeset/unlucky-pumas-design.md
+++ b/.changeset/unlucky-pumas-design.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+feat: expose fetch options in HubHttpUrlOptions

--- a/docs/pages/reference/js/types.mdx
+++ b/docs/pages/reference/js/types.mdx
@@ -146,6 +146,8 @@ export type FrameActionPayload = {
 export type HubHttpUrlOptions = {
   /** Hub HTTP REST API endpoint to use (default: https://nemes.farcaster.xyz:2281) */
   hubHttpUrl?: string;
+  /** Hub HTTP request options (use this for setting API keys) */
+  hubRequestOptions?: RequestInit;
 };
 
 /** Data extracted and parsed from the frame message body */
@@ -175,5 +177,4 @@ export type FrameActionHubContext = {
   /** User data of the requester */
   requesterUserData: UserDataReturnType;
 };
-
 ```

--- a/examples/framesjs-starter/CHANGELOG.md
+++ b/examples/framesjs-starter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # framesjs-starter
 
+## 0.1.6
+
+### Patch Changes
+
+- ccd3302: feat: JSX-based frame image rendering
+- Updated dependencies [ccd3302]
+  - frames.js@0.4.0
+
 ## 0.1.5
 
 ### Patch Changes

--- a/examples/framesjs-starter/app/examples/user-data/generate-image.tsx
+++ b/examples/framesjs-starter/app/examples/user-data/generate-image.tsx
@@ -1,87 +1,87 @@
-import { FrameActionDataParsedAndHubContext } from "frames.js";
-import * as fs from "fs";
-import { join } from "path";
-import satori from "satori";
-import sharp from "sharp";
+// import { FrameActionDataParsedAndHubContext } from "frames.js";
+// import * as fs from "fs";
+// import { join } from "path";
+// import satori from "satori";
+// import sharp from "sharp";
 
-const interRegPath = join(process.cwd(), "public/Inter-Regular.ttf");
-let interReg = fs.readFileSync(interRegPath);
+// const interRegPath = join(process.cwd(), "public/Inter-Regular.ttf");
+// let interReg = fs.readFileSync(interRegPath);
 
-export async function generateImage(
-  actionPayload: FrameActionDataParsedAndHubContext | null
-) {
-  const imageSvg = await satori(
-    <div
-      style={{
-        display: "flex", // Use flex layout
-        flexDirection: "row", // Align items horizontally
-        alignItems: "stretch", // Stretch items to fill the container height
-        width: "100%",
-        height: "100vh", // Full viewport height
-        backgroundColor: "white",
-      }}
-    >
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "center",
-          alignItems: "center",
-          paddingLeft: 24,
-          paddingRight: 24,
-          lineHeight: 1.2,
-          fontSize: 36,
-          color: "black",
-          flex: 1,
-          overflow: "hidden",
-          marginTop: 24,
-        }}
-      >
-        {actionPayload ? (
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-            }}
-          >
-            GM, {actionPayload.requesterUserData?.displayName}! Your FID is{" "}
-            {actionPayload.requesterFid}
-            {", "}
-            {actionPayload.requesterFid < 20_000
-              ? "you're OG!"
-              : "welcome to the Farcaster!"}
-          </div>
-        ) : (
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-            }}
-          >
-            Say GM
-          </div>
-        )}
-      </div>
-    </div>,
-    {
-      width: 1146,
-      height: 600,
-      fonts: [
-        {
-          name: "Inter",
-          data: interReg,
-          weight: 400,
-          style: "normal",
-        },
-      ],
-    }
-  );
+// export async function generateImage(
+//   actionPayload: FrameActionDataParsedAndHubContext | null
+// ) {
+//   const imageSvg = await satori(
+//     <div
+//       style={{
+//         display: "flex", // Use flex layout
+//         flexDirection: "row", // Align items horizontally
+//         alignItems: "stretch", // Stretch items to fill the container height
+//         width: "100%",
+//         height: "100vh", // Full viewport height
+//         backgroundColor: "white",
+//       }}
+//     >
+//       <div
+//         style={{
+//           display: "flex",
+//           flexDirection: "column",
+//           justifyContent: "center",
+//           alignItems: "center",
+//           paddingLeft: 24,
+//           paddingRight: 24,
+//           lineHeight: 1.2,
+//           fontSize: 36,
+//           color: "black",
+//           flex: 1,
+//           overflow: "hidden",
+//           marginTop: 24,
+//         }}
+//       >
+//         {actionPayload ? (
+//           <div
+//             style={{
+//               display: "flex",
+//               flexDirection: "column",
+//             }}
+//           >
+//             GM, {actionPayload.requesterUserData?.displayName}! Your FID is{" "}
+//             {actionPayload.requesterFid}
+//             {", "}
+//             {actionPayload.requesterFid < 20_000
+//               ? "you're OG!"
+//               : "welcome to the Farcaster!"}
+//           </div>
+//         ) : (
+//           <div
+//             style={{
+//               display: "flex",
+//               flexDirection: "column",
+//             }}
+//           >
+//             Say GM
+//           </div>
+//         )}
+//       </div>
+//     </div>,
+//     {
+//       width: 1146,
+//       height: 600,
+//       fonts: [
+//         {
+//           name: "Inter",
+//           data: interReg,
+//           weight: 400,
+//           style: "normal",
+//         },
+//       ],
+//     }
+//   );
 
-  const imagePng = await sharp(Buffer.from(imageSvg))
-    .toFormat("png")
-    .toBuffer();
+//   const imagePng = await sharp(Buffer.from(imageSvg))
+//     .toFormat("png")
+//     .toBuffer();
 
-  const imagePngB64 = imagePng.toString("base64");
+//   const imagePngB64 = imagePng.toString("base64");
 
-  return `data:image/png;base64,${imagePngB64}`;
-}
+//   return `data:image/png;base64,${imagePngB64}`;
+// }

--- a/examples/framesjs-starter/app/examples/user-data/page.tsx
+++ b/examples/framesjs-starter/app/examples/user-data/page.tsx
@@ -10,7 +10,7 @@ import {
 } from "frames.js/next/server";
 import Link from "next/link";
 import { DEBUG_HUB_OPTIONS } from "../../debug/constants";
-import { generateImage } from "./generate-image";
+// import { generateImage } from "./generate-image";
 
 type State = {
   saidGm: boolean;
@@ -48,7 +48,7 @@ export default async function Home({
 
   // Here: do a server side side effect either sync or async (using await), such as minting an NFT if you want.
   // example: load the users credentials & check they have an NFT
-  const image = await generateImage(frameMessage);
+  // const image = await generateImage(frameMessage);
 
   console.log("info: state is:", state);
 
@@ -62,7 +62,7 @@ export default async function Home({
         state={state}
         previousFrame={previousFrame}
       >
-        <FrameImage src={image} />
+        <FrameImage src={"https://framesjs.org/og.png"} />
         {!state.saidGm ? (
           <FrameButton onClick={dispatch}>Say GM</FrameButton>
         ) : null}

--- a/examples/framesjs-starter/app/page.tsx
+++ b/examples/framesjs-starter/app/page.tsx
@@ -37,7 +37,7 @@ export default async function Home({
   const previousFrame = getPreviousFrame<State>(searchParams);
 
   const frameMessage = await getFrameMessage(previousFrame.postBody, {
-    ...DEBUG_HUB_OPTIONS,
+    hubHttpUrl: "https://nemes.farcaster.xyz:2281",
     fetchHubContext: true,
   });
 
@@ -53,10 +53,6 @@ export default async function Home({
 
   // Here: do a server side side effect either sync or async (using await), such as minting an NFT if you want.
   // example: load the users credentials & check they have an NFT
-
-  // Example with satori and sharp:
-  // const imageUrl = await
-  frameMessage;
 
   console.log("info: state is:", state);
 

--- a/examples/framesjs-starter/app/page.tsx
+++ b/examples/framesjs-starter/app/page.tsx
@@ -55,8 +55,8 @@ export default async function Home({
   // example: load the users credentials & check they have an NFT
 
   // Example with satori and sharp:
-  // const imageUrl = await 
-    (frameMessage);
+  // const imageUrl = await
+  frameMessage;
 
   console.log("info: state is:", state);
 
@@ -78,11 +78,13 @@ export default async function Home({
     console.log("info: frameMessage is:", frameMessage);
   }
 
+  const baseUrl = process.env.NEXT_PUBLIC_HOST || "http://localhost:3000";
+
   // then, when done, return next frame
   return (
     <div className="p-4">
       frames.js starter kit.{" "}
-      <Link href="/debug?url=http://localhost:3000" className="underline">
+      <Link href={`/debug?url=${baseUrl}`} className="underline">
         Debug
       </Link>
       <FrameContainer

--- a/examples/framesjs-starter/package.json
+++ b/examples/framesjs-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "framesjs-starter",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@noble/ed25519": "^2.0.0",
-    "frames.js": "^0.3.0",
+    "frames.js": "^0.4.0",
     "next": "14.1.0",
     "qrcode.react": "^3.1.0",
     "react": "^18",

--- a/examples/framesjs-starter/package.json
+++ b/examples/framesjs-starter/package.json
@@ -16,7 +16,6 @@
     "react": "^18",
     "react-dom": "^18",
     "satori": "^0.10.13",
-    "sharp": "^0.33.2",
     "swr": "^2.2.4"
   },
   "engines": {

--- a/examples/utils-starter/CHANGELOG.md
+++ b/examples/utils-starter/CHANGELOG.md
@@ -1,5 +1,12 @@
 # utils-starter
 
+## 1.0.3
+
+### Patch Changes
+
+- Updated dependencies [ccd3302]
+  - frames.js@0.4.0
+
 ## 1.0.2
 
 ### Patch Changes

--- a/examples/utils-starter/package.json
+++ b/examples/utils-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils-starter",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3004",
@@ -9,7 +9,7 @@
     "lint": "eslint . --max-warnings 0"
   },
   "dependencies": {
-    "frames.js": "^0.3.0",
+    "frames.js": "^0.4.0",
     "next": "^14.0.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/packages/frames.js/CHANGELOG.md
+++ b/packages/frames.js/CHANGELOG.md
@@ -1,5 +1,11 @@
 # frames.js
 
+## 0.4.0
+
+### Minor Changes
+
+- ccd3302: feat: JSX-based frame image rendering
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/frames.js/package.json
+++ b/packages/frames.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frames.js",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/frames.js/src/getAddressForFid.ts
+++ b/packages/frames.js/src/getAddressForFid.ts
@@ -20,10 +20,12 @@ export async function getAddressForFid<
   const optionsOrDefaults = {
     fallbackToCustodyAddress: options.fallbackToCustodyAddress ?? true,
     hubHttpUrl: options.hubHttpUrl ?? "https://nemes.farcaster.xyz:2281",
+    hubRequestOptions: options.hubRequestOptions ?? {},
   };
 
   const verificationsResponse = await fetch(
-    `${optionsOrDefaults.hubHttpUrl}/v1/verificationsByFid?fid=${fid}`
+    `${optionsOrDefaults.hubHttpUrl}/v1/verificationsByFid?fid=${fid}`,
+    optionsOrDefaults.hubRequestOptions
   );
   const { messages } = await verificationsResponse.json();
   if (messages[0]) {

--- a/packages/frames.js/src/getFrameMessage.ts
+++ b/packages/frames.js/src/getFrameMessage.ts
@@ -30,6 +30,7 @@ export async function getFrameMessage<T extends GetFrameMessageOptions>(
   const optionsOrDefaults = {
     fetchHubContext: options?.fetchHubContext ?? true,
     hubHttpUrl: options?.hubHttpUrl || "https://nemes.farcaster.xyz:2281",
+    hubRequestOptions: options?.hubRequestOptions || {},
   };
 
   const decodedMessage = Message.decode(
@@ -66,29 +67,36 @@ export async function getFrameMessage<T extends GetFrameMessageOptions>(
     ] = await Promise.all([
       validateFrameMessage(payload, {
         hubHttpUrl: optionsOrDefaults.hubHttpUrl,
+        hubRequestOptions: optionsOrDefaults.hubRequestOptions,
       }),
       fetch(
-        `${optionsOrDefaults.hubHttpUrl}/v1/linkById?fid=${requesterFid}&target_fid=${castId?.fid}&link_type=follow`
+        `${optionsOrDefaults.hubHttpUrl}/v1/linkById?fid=${requesterFid}&target_fid=${castId?.fid}&link_type=follow`,
+        optionsOrDefaults.hubRequestOptions
       ).then((res) => res.ok || requesterFid === castId?.fid),
       fetch(
-        `${optionsOrDefaults.hubHttpUrl}/v1/linkById?fid=${castId?.fid}&target_fid=${requesterFid}&link_type=follow`
+        `${optionsOrDefaults.hubHttpUrl}/v1/linkById?fid=${castId?.fid}&target_fid=${requesterFid}&link_type=follow`,
+        optionsOrDefaults.hubRequestOptions
       ).then((res) => res.ok || requesterFid === castId?.fid),
       fetch(
-        `${optionsOrDefaults.hubHttpUrl}/v1/reactionById?fid=${requesterFid}&reaction_type=1&target_fid=${castId?.fid}&target_hash=${castId?.hash}`
+        `${optionsOrDefaults.hubHttpUrl}/v1/reactionById?fid=${requesterFid}&reaction_type=1&target_fid=${castId?.fid}&target_hash=${castId?.hash}`,
+        optionsOrDefaults.hubRequestOptions
       ).then((res) => res.ok),
       fetch(
-        `${optionsOrDefaults.hubHttpUrl}/v1/reactionById?fid=${requesterFid}&reaction_type=2&target_fid=${castId?.fid}&target_hash=${castId?.hash}`
+        `${optionsOrDefaults.hubHttpUrl}/v1/reactionById?fid=${requesterFid}&reaction_type=2&target_fid=${castId?.fid}&target_hash=${castId?.hash}`,
+        optionsOrDefaults.hubRequestOptions
       ).then((res) => res.ok),
       getAddressForFid({
         fid: requesterFid,
         options: {
           hubHttpUrl: optionsOrDefaults.hubHttpUrl,
+          hubRequestOptions: optionsOrDefaults.hubRequestOptions,
         },
       }),
       getUserDataForFid({
         fid: requesterFid,
         options: {
           hubHttpUrl: optionsOrDefaults.hubHttpUrl,
+          hubRequestOptions: optionsOrDefaults.hubRequestOptions,
         },
       }),
     ]);

--- a/packages/frames.js/src/getUserDataForFid.ts
+++ b/packages/frames.js/src/getUserDataForFid.ts
@@ -16,10 +16,12 @@ export async function getUserDataForFid<
 }): Promise<UserDataReturnType> {
   const optionsOrDefaults = {
     hubHttpUrl: options.hubHttpUrl ?? "https://nemes.farcaster.xyz:2281",
+    hubRequestOptions: options.hubRequestOptions ?? {},
   };
 
   const userDataResponse = await fetch(
-    `${optionsOrDefaults.hubHttpUrl}/v1/userDataByFid?fid=${fid}`
+    `${optionsOrDefaults.hubHttpUrl}/v1/userDataByFid?fid=${fid}`,
+    optionsOrDefaults.hubRequestOptions
   );
 
   const { messages } = await userDataResponse.json();

--- a/packages/frames.js/src/next/server.tsx
+++ b/packages/frames.js/src/next/server.tsx
@@ -43,10 +43,19 @@ export async function validateActionSignature(
   frameActionPayload: FrameActionPayload | null,
   options?: HubHttpUrlOptions
 ): Promise<FrameActionMessage | null> {
+  if (options?.hubHttpUrl) {
+    if (!options.hubHttpUrl.startsWith("http")) {
+      throw new Error(
+        `frames.js: Invalid Hub URL: ${options?.hubHttpUrl}, ensure you have included the protocol (e.g. https://)`
+      );
+    }
+  }
+
   if (!frameActionPayload) {
     // no payload means no action
     return null;
   }
+
   const { isValid, message } = await validateFrameMessage(
     frameActionPayload,
     options
@@ -67,6 +76,14 @@ export async function getFrameMessage<T extends GetFrameMessageOptions>(
   frameActionPayload: FrameActionPayload | null,
   options?: T
 ): Promise<FrameMessageReturnType<T> | null> {
+  if (options?.hubHttpUrl) {
+    if (!options.hubHttpUrl.startsWith("http")) {
+      throw new Error(
+        `frames.js: Invalid Hub URL: ${options?.hubHttpUrl}, ensure you have included the protocol (e.g. https://)`
+      );
+    }
+  }
+
   if (!frameActionPayload) {
     console.log(
       "info: no frameActionPayload, this is expected for the homeframe"

--- a/packages/frames.js/src/types.ts
+++ b/packages/frames.js/src/types.ts
@@ -151,6 +151,8 @@ export type FrameActionPayload = {
 export type HubHttpUrlOptions = {
   /** Hub HTTP REST API endpoint to use (default: https://nemes.farcaster.xyz:2281) */
   hubHttpUrl?: string;
+  /** Hub HTTP request options (use this for setting API keys) */
+  hubRequestOptions?: RequestInit;
 };
 
 /** Data extracted and parsed from the frame message body */

--- a/packages/frames.js/src/validateFrameMessage.ts
+++ b/packages/frames.js/src/validateFrameMessage.ts
@@ -15,8 +15,9 @@ export async function validateFrameMessage(
   isValid: boolean;
   message: FrameActionMessage | undefined;
 }> {
-  const optionsOrDefaults: HubHttpUrlOptions = {
+  const optionsOrDefaults = {
     hubHttpUrl: options?.hubHttpUrl || "https://nemes.farcaster.xyz:2281",
+    hubRequestOptions: options?.hubRequestOptions ?? {},
   };
 
   const validateMessageResponse = await fetch(
@@ -25,8 +26,10 @@ export async function validateFrameMessage(
       method: "POST",
       headers: {
         "Content-Type": "application/octet-stream",
+        ...optionsOrDefaults.hubRequestOptions.headers,
       },
       body: hexStringToUint8Array(body.trustedData.messageBytes),
+      ...optionsOrDefaults.hubRequestOptions.headers,
     }
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -558,13 +558,6 @@
     picocolors "^1.0.0"
     sisteransi "^1.0.5"
 
-"@emnapi/runtime@^0.45.0":
-  version "0.45.0"
-  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-0.45.0.tgz#e754de04c683263f34fd0c7f32adfe718bbe4ddd"
-  integrity sha512-Txumi3td7J4A/xTTwlssKieHKTGl3j4A1tglBx72auZ49YK7ePY6XZricgIg9mnZT4xPfA+UPCUdnhRuEFDL+w==
-  dependencies:
-    tslib "^2.4.0"
-
 "@emotion/hash@^0.9.0":
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.1.tgz#4ffb0055f7ef676ebc3a5a91fb621393294e2f43"
@@ -788,119 +781,6 @@
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz#d9fae00a2d5cb40f92cfe64b47ad749fbc38f917"
   integrity sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==
-
-"@img/sharp-darwin-arm64@0.33.2":
-  version "0.33.2"
-  resolved "https://registry.yarnpkg.com/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.2.tgz#0a52a82c2169112794dac2c71bfba9e90f7c5bd1"
-  integrity sha512-itHBs1rPmsmGF9p4qRe++CzCgd+kFYktnsoR1sbIAfsRMrJZau0Tt1AH9KVnufc2/tU02Gf6Ibujx+15qRE03w==
-  optionalDependencies:
-    "@img/sharp-libvips-darwin-arm64" "1.0.1"
-
-"@img/sharp-darwin-x64@0.33.2":
-  version "0.33.2"
-  resolved "https://registry.yarnpkg.com/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.2.tgz#982e26bb9d38a81f75915c4032539aed621d1c21"
-  integrity sha512-/rK/69Rrp9x5kaWBjVN07KixZanRr+W1OiyKdXcbjQD6KbW+obaTeBBtLUAtbBsnlTTmWthw99xqoOS7SsySDg==
-  optionalDependencies:
-    "@img/sharp-libvips-darwin-x64" "1.0.1"
-
-"@img/sharp-libvips-darwin-arm64@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.1.tgz#81e83ffc2c497b3100e2f253766490f8fad479cd"
-  integrity sha512-kQyrSNd6lmBV7O0BUiyu/OEw9yeNGFbQhbxswS1i6rMDwBBSX+e+rPzu3S+MwAiGU3HdLze3PanQ4Xkfemgzcw==
-
-"@img/sharp-libvips-darwin-x64@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.1.tgz#fc1fcd9d78a178819eefe2c1a1662067a83ab1d6"
-  integrity sha512-eVU/JYLPVjhhrd8Tk6gosl5pVlvsqiFlt50wotCvdkFGf+mDNBJxMh+bvav+Wt3EBnNZWq8Sp2I7XfSjm8siog==
-
-"@img/sharp-libvips-linux-arm64@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.1.tgz#26eb8c556a9b0db95f343fc444abc3effb67ebcf"
-  integrity sha512-bnGG+MJjdX70mAQcSLxgeJco11G+MxTz+ebxlz8Y3dxyeb3Nkl7LgLI0mXupoO+u1wRNx/iRj5yHtzA4sde1yA==
-
-"@img/sharp-libvips-linux-arm@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.1.tgz#2a377b959ff7dd6528deee486c25461296a4fa8b"
-  integrity sha512-FtdMvR4R99FTsD53IA3LxYGghQ82t3yt0ZQ93WMZ2xV3dqrb0E8zq4VHaTOuLEAuA83oDawHV3fd+BsAPadHIQ==
-
-"@img/sharp-libvips-linux-s390x@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.1.tgz#af28ac9ba929204467ecdf843330d791e9421e10"
-  integrity sha512-3+rzfAR1YpMOeA2zZNp+aYEzGNWK4zF3+sdMxuCS3ey9HhDbJ66w6hDSHDMoap32DueFwhhs3vwooAB2MaK4XQ==
-
-"@img/sharp-libvips-linux-x64@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.1.tgz#4273d182aa51912e655e1214ea47983d7c1f7f8d"
-  integrity sha512-3NR1mxFsaSgMMzz1bAnnKbSAI+lHXVTqAHgc1bgzjHuXjo4hlscpUxc0vFSAPKI3yuzdzcZOkq7nDPrP2F8Jgw==
-
-"@img/sharp-libvips-linuxmusl-arm64@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.1.tgz#d150c92151cea2e8d120ad168b9c358d09c77ce8"
-  integrity sha512-5aBRcjHDG/T6jwC3Edl3lP8nl9U2Yo8+oTl5drd1dh9Z1EBfzUKAJFUDTDisDjUwc7N4AjnPGfCA3jl3hY8uDg==
-
-"@img/sharp-libvips-linuxmusl-x64@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.1.tgz#e297c1a4252c670d93b0f9e51fca40a7a5b6acfd"
-  integrity sha512-dcT7inI9DBFK6ovfeWRe3hG30h51cBAP5JXlZfx6pzc/Mnf9HFCQDLtYf4MCBjxaaTfjCCjkBxcy3XzOAo5txw==
-
-"@img/sharp-linux-arm64@0.33.2":
-  version "0.33.2"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.2.tgz#af3409f801a9bee1d11d0c7e971dcd6180f80022"
-  integrity sha512-pz0NNo882vVfqJ0yNInuG9YH71smP4gRSdeL09ukC2YLE6ZyZePAlWKEHgAzJGTiOh8Qkaov6mMIMlEhmLdKew==
-  optionalDependencies:
-    "@img/sharp-libvips-linux-arm64" "1.0.1"
-
-"@img/sharp-linux-arm@0.33.2":
-  version "0.33.2"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.2.tgz#181f7466e6ac074042a38bfb679eb82505e17083"
-  integrity sha512-Fndk/4Zq3vAc4G/qyfXASbS3HBZbKrlnKZLEJzPLrXoJuipFNNwTes71+Ki1hwYW5lch26niRYoZFAtZVf3EGA==
-  optionalDependencies:
-    "@img/sharp-libvips-linux-arm" "1.0.1"
-
-"@img/sharp-linux-s390x@0.33.2":
-  version "0.33.2"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.2.tgz#9c171f49211f96fba84410b3e237b301286fa00f"
-  integrity sha512-MBoInDXDppMfhSzbMmOQtGfloVAflS2rP1qPcUIiITMi36Mm5YR7r0ASND99razjQUpHTzjrU1flO76hKvP5RA==
-  optionalDependencies:
-    "@img/sharp-libvips-linux-s390x" "1.0.1"
-
-"@img/sharp-linux-x64@0.33.2":
-  version "0.33.2"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.2.tgz#b956dfc092adc58c2bf0fae2077e6f01a8b2d5d7"
-  integrity sha512-xUT82H5IbXewKkeF5aiooajoO1tQV4PnKfS/OZtb5DDdxS/FCI/uXTVZ35GQ97RZXsycojz/AJ0asoz6p2/H/A==
-  optionalDependencies:
-    "@img/sharp-libvips-linux-x64" "1.0.1"
-
-"@img/sharp-linuxmusl-arm64@0.33.2":
-  version "0.33.2"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.2.tgz#10e0ec5a79d1234c6a71df44c9f3b0bef0bc0f15"
-  integrity sha512-F+0z8JCu/UnMzg8IYW1TMeiViIWBVg7IWP6nE0p5S5EPQxlLd76c8jYemG21X99UzFwgkRo5yz2DS+zbrnxZeA==
-  optionalDependencies:
-    "@img/sharp-libvips-linuxmusl-arm64" "1.0.1"
-
-"@img/sharp-linuxmusl-x64@0.33.2":
-  version "0.33.2"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.2.tgz#29e0030c24aa27c38201b1fc84e3d172899fcbe0"
-  integrity sha512-+ZLE3SQmSL+Fn1gmSaM8uFusW5Y3J9VOf+wMGNnTtJUMUxFhv+P4UPaYEYT8tqnyYVaOVGgMN/zsOxn9pSsO2A==
-  optionalDependencies:
-    "@img/sharp-libvips-linuxmusl-x64" "1.0.1"
-
-"@img/sharp-wasm32@0.33.2":
-  version "0.33.2"
-  resolved "https://registry.yarnpkg.com/@img/sharp-wasm32/-/sharp-wasm32-0.33.2.tgz#38d7c740a22de83a60ad1e6bcfce17462b0d4230"
-  integrity sha512-fLbTaESVKuQcpm8ffgBD7jLb/CQLcATju/jxtTXR1XCLwbOQt+OL5zPHSDMmp2JZIeq82e18yE0Vv7zh6+6BfQ==
-  dependencies:
-    "@emnapi/runtime" "^0.45.0"
-
-"@img/sharp-win32-ia32@0.33.2":
-  version "0.33.2"
-  resolved "https://registry.yarnpkg.com/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.2.tgz#09456314e223f68e5417c283b45c399635c16202"
-  integrity sha512-okBpql96hIGuZ4lN3+nsAjGeggxKm7hIRu9zyec0lnfB8E7Z6p95BuRZzDDXZOl2e8UmR4RhYt631i7mfmKU8g==
-
-"@img/sharp-win32-x64@0.33.2":
-  version "0.33.2"
-  resolved "https://registry.yarnpkg.com/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.2.tgz#148e96dfd6e68747da41a311b9ee4559bb1b1471"
-  integrity sha512-E4magOks77DK47FwHUIGH0RYWSgRBfGdK56kIHSVeB9uIS4pPFr4N2kIVsXdQQo4LzOsENKV5KAhRlRL7eMAdg==
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
@@ -3033,26 +2913,10 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
-color-name@^1.0.0, color-name@^1.1.4, color-name@~1.1.4:
+color-name@^1.1.4, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
-color-string@^1.9.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
-  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
-  dependencies:
-    color-name "^1.0.0"
-    simple-swizzle "^0.2.2"
-
-color@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/color/-/color-4.2.3.tgz#d781ecb5e57224ee43ea9627560107c0e0c6463a"
-  integrity sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==
-  dependencies:
-    color-convert "^2.0.1"
-    color-string "^1.9.0"
 
 comma-separated-tokens@^2.0.0:
   version "2.0.3"
@@ -3331,11 +3195,6 @@ detect-indent@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-7.0.1.tgz#cbb060a12842b9c4d333f1cac4aa4da1bb66bc25"
   integrity sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==
-
-detect-libc@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.2.tgz#8ccf2ba9315350e1241b88d0ac3b0e1fbd99605d"
-  integrity sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -4843,11 +4702,6 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
-
-is-arrayish@^0.3.1:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
-  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-async-function@^2.0.0:
   version "2.0.0"
@@ -7852,35 +7706,6 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-sharp@^0.33.2:
-  version "0.33.2"
-  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.33.2.tgz#fcd52f2c70effa8a02160b1bfd989a3de55f2dfb"
-  integrity sha512-WlYOPyyPDiiM07j/UO+E720ju6gtNtHjEGg5vovUk1Lgxyjm2LFO+37Nt/UI3MMh2l6hxTWQWi7qk3cXJTutcQ==
-  dependencies:
-    color "^4.2.3"
-    detect-libc "^2.0.2"
-    semver "^7.5.4"
-  optionalDependencies:
-    "@img/sharp-darwin-arm64" "0.33.2"
-    "@img/sharp-darwin-x64" "0.33.2"
-    "@img/sharp-libvips-darwin-arm64" "1.0.1"
-    "@img/sharp-libvips-darwin-x64" "1.0.1"
-    "@img/sharp-libvips-linux-arm" "1.0.1"
-    "@img/sharp-libvips-linux-arm64" "1.0.1"
-    "@img/sharp-libvips-linux-s390x" "1.0.1"
-    "@img/sharp-libvips-linux-x64" "1.0.1"
-    "@img/sharp-libvips-linuxmusl-arm64" "1.0.1"
-    "@img/sharp-libvips-linuxmusl-x64" "1.0.1"
-    "@img/sharp-linux-arm" "0.33.2"
-    "@img/sharp-linux-arm64" "0.33.2"
-    "@img/sharp-linux-s390x" "0.33.2"
-    "@img/sharp-linux-x64" "0.33.2"
-    "@img/sharp-linuxmusl-arm64" "0.33.2"
-    "@img/sharp-linuxmusl-x64" "0.33.2"
-    "@img/sharp-wasm32" "0.33.2"
-    "@img/sharp-win32-ia32" "0.33.2"
-    "@img/sharp-win32-x64" "0.33.2"
-
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -7950,13 +7775,6 @@ signal-exit@^4.0.1:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
-
-simple-swizzle@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
-  integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
-  dependencies:
-    is-arrayish "^0.3.1"
 
 sisteransi@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
## Change Summary

- Exposes `RequestInit` of fetch requests made to Hub HTTP endpoints. Useful for including API keys when making authenticated requests to hub providers such as Neynar.

Usage:
```ts
const message = await getFrameMessage(frameActionPayload, {
  hubHttpUrl: 'https://api.neynar.com:2281',
  hubRequestOptions: {
    headers: {
      api_key: process.env.NEYNAR_API_KEY
    }
  }
})
```

- Throws more useful error when specifying an invalid hub url in nextjs

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
