### PR TITLE
fix: use neynar hubs as fallback, clean up options defaults

### DIFF
--- a/.changeset/proud-books-turn.md
+++ b/.changeset/proud-books-turn.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix: use nested destructuring for options defaults

--- a/.changeset/wicked-pianos-wait.md
+++ b/.changeset/wicked-pianos-wait.md
@@ -1,0 +1,6 @@
+---
+"framesjs-starter": patch
+"frames.js": patch
+---
+
+fix: use neynar hubs as fallback

--- a/docs/pages/reference/js/types.mdx
+++ b/docs/pages/reference/js/types.mdx
@@ -144,7 +144,7 @@ export type FrameActionPayload = {
 
 /** Options available in functions that make use of Hub queries */
 export type HubHttpUrlOptions = {
-  /** Hub HTTP REST API endpoint to use (default: https://nemes.farcaster.xyz:2281) */
+  /** Hub HTTP REST API endpoint to use (default: https://api.neynar.com:2281 w/ public API key) */
   hubHttpUrl?: string;
   /** Hub HTTP request options (use this for setting API keys) */
   hubRequestOptions?: RequestInit;

--- a/examples/framesjs-starter/app/debug/frame-action/route.ts
+++ b/examples/framesjs-starter/app/debug/frame-action/route.ts
@@ -34,8 +34,6 @@ export async function POST(req: NextRequest) {
       url: body.untrustedData.url,
     });
 
-    console.log(frame);
-
     return Response.json({ frame, errors });
   } catch (err) {
     console.error(err);

--- a/examples/framesjs-starter/app/debug/hub/[...hubPath]/route.ts
+++ b/examples/framesjs-starter/app/debug/hub/[...hubPath]/route.ts
@@ -1,16 +1,28 @@
 import { NextRequest } from "next/server";
 
-function getHubUrl(url: string, hubPath: string[]) {
+function getHubRequest(request: NextRequest, hubPath: string[]) {
+  const { url, headers: originalHeaders, ...rest } = request;
+
   const newUrl = new URL(url);
   newUrl.protocol = "https";
-  newUrl.hostname = "nemes.farcaster.xyz";
+  newUrl.hostname = "api.neynar.com";
   newUrl.port = "2281";
   newUrl.pathname = hubPath.join("/");
-  return newUrl;
-}
 
-const host =
-  process.env.NEXT_PUBLIC_HOST?.replace("http://", "") ?? "localhost:3000";
+  const headers = new Headers({
+    ...originalHeaders,
+    api_key: "NEYNAR_FRAMES_JS",
+  });
+  headers.delete("host");
+  headers.delete("referer");
+
+  const hubRequest = new Request(newUrl, {
+    headers,
+    ...rest,
+  });
+
+  return hubRequest;
+}
 
 export async function GET(
   request: NextRequest,
@@ -20,16 +32,8 @@ export async function GET(
     `info: Mock hub: Forwarding message ${hubPath.join("/")} to a real hub`
   );
 
-  const url = getHubUrl(request.url, hubPath);
-
-  const requestHeaders = new Headers(request.headers);
-  // Remove in order to fix this: https://github.com/node-fetch/node-fetch/discussions/1678
-  requestHeaders.delete("host");
-  requestHeaders.delete("referer");
-  const response = await fetch(url, {
-    headers: requestHeaders,
-  });
-
+  const hubRequest = getHubRequest(request, hubPath);
+  const response = await fetch(hubRequest);
   return response;
 }
 
@@ -37,17 +41,11 @@ export async function POST(
   request: NextRequest,
   { params: { hubPath } }: { params: { hubPath: string[] } }
 ) {
-  const url = getHubUrl(request.url, hubPath);
-  const requestHeaders = new Headers(request.headers);
+  console.warn(
+    `info: Mock hub: Forwarding message ${hubPath.join("/")} to a real hub`
+  );
 
-  // Remove in order to fix this: https://github.com/node-fetch/node-fetch/discussions/1678
-  requestHeaders.delete("host");
-  requestHeaders.delete("referer");
-
-  const response = await fetch(url, {
-    method: "POST",
-    headers: requestHeaders,
-    body: request.body,
-  });
+  const hubRequest = getHubRequest(request, hubPath);
+  const response = await fetch(hubRequest);
   return response;
 }

--- a/examples/framesjs-starter/app/debug/hub/[...hubPath]/route.ts
+++ b/examples/framesjs-starter/app/debug/hub/[...hubPath]/route.ts
@@ -10,8 +10,8 @@ function getHubRequest(request: NextRequest, hubPath: string[]) {
   newUrl.pathname = hubPath.join("/");
 
   const headers = new Headers({
-    ...originalHeaders,
     api_key: "NEYNAR_FRAMES_JS",
+    ...originalHeaders,
   });
   headers.delete("host");
   headers.delete("referer");

--- a/examples/framesjs-starter/app/examples/user-data/page.tsx
+++ b/examples/framesjs-starter/app/examples/user-data/page.tsx
@@ -33,7 +33,6 @@ export default async function Home({
 
   const frameMessage = await getFrameMessage(previousFrame.postBody, {
     ...DEBUG_HUB_OPTIONS,
-    fetchHubContext: true,
   });
 
   if (frameMessage && !frameMessage?.isValid) {

--- a/examples/framesjs-starter/app/page.tsx
+++ b/examples/framesjs-starter/app/page.tsx
@@ -37,8 +37,7 @@ export default async function Home({
   const previousFrame = getPreviousFrame<State>(searchParams);
 
   const frameMessage = await getFrameMessage(previousFrame.postBody, {
-    hubHttpUrl: "https://nemes.farcaster.xyz:2281",
-    fetchHubContext: true,
+    ...DEBUG_HUB_OPTIONS,
   });
 
   if (frameMessage && !frameMessage?.isValid) {

--- a/packages/frames.js/src/getAddressForFid.ts
+++ b/packages/frames.js/src/getAddressForFid.ts
@@ -13,19 +13,22 @@ export async function getAddressForFid<
   fid,
   options = {},
 }: {
-  /** the user's Farcaster fid, found in the FrameActionPayload message `fid` */
   fid: number;
   options?: Options;
 }): Promise<AddressReturnType<Options>> {
-  const optionsOrDefaults = {
-    fallbackToCustodyAddress: options.fallbackToCustodyAddress ?? true,
-    hubHttpUrl: options.hubHttpUrl ?? "https://nemes.farcaster.xyz:2281",
-    hubRequestOptions: options.hubRequestOptions ?? {},
-  };
+  const {
+    fallbackToCustodyAddress = true,
+    hubHttpUrl = "https://api.neynar.com:2281",
+    hubRequestOptions = {
+      headers: {
+        api_key: "NEYNAR_FRAMES_JS",
+      },
+    },
+  } = options;
 
   const verificationsResponse = await fetch(
-    `${optionsOrDefaults.hubHttpUrl}/v1/verificationsByFid?fid=${fid}`,
-    optionsOrDefaults.hubRequestOptions
+    `${hubHttpUrl}/v1/verificationsByFid?fid=${fid}`,
+    hubRequestOptions
   );
   const { messages } = await verificationsResponse.json();
   if (messages[0]) {
@@ -35,7 +38,7 @@ export async function getAddressForFid<
       },
     } = messages[0];
     return address;
-  } else if (optionsOrDefaults.fallbackToCustodyAddress) {
+  } else if (fallbackToCustodyAddress) {
     const publicClient = createPublicClient({
       transport: http(),
       chain: optimism,

--- a/packages/frames.js/src/getUserDataForFid.ts
+++ b/packages/frames.js/src/getUserDataForFid.ts
@@ -10,18 +10,21 @@ export async function getUserDataForFid<
   fid,
   options = {},
 }: {
-  /** the user's Farcaster fid` */
   fid: number;
   options?: Options;
 }): Promise<UserDataReturnType> {
-  const optionsOrDefaults = {
-    hubHttpUrl: options.hubHttpUrl ?? "https://nemes.farcaster.xyz:2281",
-    hubRequestOptions: options.hubRequestOptions ?? {},
-  };
+  const {
+    hubHttpUrl = "https://api.neynar.com:2281",
+    hubRequestOptions = {
+      headers: {
+        api_key: "NEYNAR_FRAMES_JS",
+      },
+    },
+  } = options;
 
   const userDataResponse = await fetch(
-    `${optionsOrDefaults.hubHttpUrl}/v1/userDataByFid?fid=${fid}`,
-    optionsOrDefaults.hubRequestOptions
+    `${hubHttpUrl}/v1/userDataByFid?fid=${fid}`,
+    hubRequestOptions
   );
 
   const { messages } = await userDataResponse.json();

--- a/packages/frames.js/src/types.ts
+++ b/packages/frames.js/src/types.ts
@@ -154,7 +154,7 @@ export type FrameActionPayload = {
 
 /** Options available in functions that make use of Hub queries */
 export type HubHttpUrlOptions = {
-  /** Hub HTTP REST API endpoint to use (default: https://nemes.farcaster.xyz:2281) */
+  /** Hub HTTP REST API endpoint to use (default: https://api.neynar.com:2281 w/ public API key) */
   hubHttpUrl?: string;
   /** Hub HTTP request options (use this for setting API keys) */
   hubRequestOptions?: RequestInit;

--- a/packages/frames.js/src/validateFrameMessage.ts
+++ b/packages/frames.js/src/validateFrameMessage.ts
@@ -10,26 +10,29 @@ import { FrameActionMessage, Message } from "@farcaster/core";
  */
 export async function validateFrameMessage(
   body: FrameActionPayload,
-  options?: HubHttpUrlOptions
+  {
+    hubHttpUrl = "https://api.neynar.com:2281",
+    hubRequestOptions = {
+      headers: {
+        api_key: "NEYNAR_FRAMES_JS",
+      },
+    },
+  }: HubHttpUrlOptions = {}
 ): Promise<{
   isValid: boolean;
   message: FrameActionMessage | undefined;
 }> {
-  const optionsOrDefaults = {
-    hubHttpUrl: options?.hubHttpUrl || "https://nemes.farcaster.xyz:2281",
-    hubRequestOptions: options?.hubRequestOptions ?? {},
-  };
-
+  const { headers, ...rest } = hubRequestOptions;
   const validateMessageResponse = await fetch(
-    `${optionsOrDefaults.hubHttpUrl}/v1/validateMessage`,
+    `${hubHttpUrl}/v1/validateMessage`,
     {
       method: "POST",
       headers: {
         "Content-Type": "application/octet-stream",
-        ...optionsOrDefaults.hubRequestOptions.headers,
+        ...headers,
       },
       body: hexStringToUint8Array(body.trustedData.messageBytes),
-      ...optionsOrDefaults.hubRequestOptions.headers,
+      ...rest,
     }
   );
 


### PR DESCRIPTION
## Change Summary

- Use use neynar hubs as fallback with public API key
- Clean up options defaults
- Fix `getFrameMessage` return type

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
