### PR TITLE
chore: add meta frame.imageAspectRatio to getFrameHtmlHead fn in getFrameHtml.ts

### DIFF
--- a/.changeset/long-cows-matter.md
+++ b/.changeset/long-cows-matter.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+add meta frame.imageAspectRatio to getFrameHtmlHead fn in getFrameHtml.ts

--- a/packages/frames.js/src/getFrameHtml.ts
+++ b/packages/frames.js/src/getFrameHtml.ts
@@ -45,6 +45,9 @@ export function getFrameHtmlHead(frame: Frame): string {
     `<meta name="fc:frame" content="${frame.version}"/>`,
     `<meta name="fc:frame:image" content="${frame.image}"/>`,
     `<meta name="fc:frame:post_url" content="${frame.postUrl}"/>`,
+    frame.imageAspectRatio 
+      ? `<meta name="fc:frame:image:aspect_ratio" content="${frame.imageAspectRatio}"/>`
+      : "",
     frame.inputText
       ? `<meta name="fc:frame:input:text" content="${frame.inputText}"/>`
       : "",


### PR DESCRIPTION
## Change Summary

The `frames.js 0.4.2` version includes support to `fc:frame:image:aspect_ratio` is in `Frame` type definition, but the prop is missing in `getFrameHtmlHead()` I've just added the meta tag creation if is in `frame` object.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
