### PR TITLE
fix: update starter script steps

### DIFF
--- a/examples/framesjs-starter/README.md
+++ b/examples/framesjs-starter/README.md
@@ -4,6 +4,11 @@ This is a boilerplate repo to get started quickly with `frames.js`
 
 ## Quickstart
 
+If running from the frames.js repository itself:
+
+- Run `yarn` from the repository root
+- Run `cd examples/framesjs-starter`
+
 1. Install dependencies `yarn install`
 
 2. Run the dev server `yarn dev`


### PR DESCRIPTION
This PR updates the starter script README to reflect the need for running `yarn` in the root directory when running `framesjs-starter` from the context of the monorepo.

## Change Summary

- Ensures `frames.js` is built so that the example can be ran

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] N/A, starter docs only ~~PR has a [Changeset](CONTRIBUTING.md)~~
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
