### PR TITLE
fix: remove mint action from demo as it breaks warpcast image rendering

### DIFF
--- a/examples/framesjs-starter/app/debug/page.tsx
+++ b/examples/framesjs-starter/app/debug/page.tsx
@@ -228,6 +228,15 @@ export default function Page({
             >
               Multi-page
             </button>
+            <button
+              className="underline"
+              onClick={(e) => {
+                e.preventDefault();
+                router.push(`?url=${baseUrl}/examples/mint-button`);
+              }}
+            >
+              Mint button
+            </button>
           </div>
           <LoginWindow
             farcasterUser={farcasterUser}

--- a/examples/framesjs-starter/app/examples/mint-button/frames/route.ts
+++ b/examples/framesjs-starter/app/examples/mint-button/frames/route.ts
@@ -1,0 +1,1 @@
+export { POST } from "frames.js/next/server";

--- a/examples/framesjs-starter/app/examples/mint-button/page.tsx
+++ b/examples/framesjs-starter/app/examples/mint-button/page.tsx
@@ -1,0 +1,89 @@
+import { getTokenUrl } from "frames.js";
+import {
+  FrameButton,
+  FrameContainer,
+  FrameImage,
+  FrameReducer,
+  NextServerPageProps,
+  getPreviousFrame,
+  useFramesReducer,
+} from "frames.js/next/server";
+import Link from "next/link";
+import { zora } from "viem/chains";
+
+type State = {
+  pageIndex: number;
+};
+
+const nfts: {
+  src: string;
+  tokenUrl: string;
+}[] = [
+  {
+    src: "https://ipfs.decentralized-content.com/ipfs/bafybeifs7vasy5zbmnpixt7tb6efi35kcrmpoz53d3vg5pwjz52q7fl6pq/cook.png",
+    tokenUrl: getTokenUrl({
+      address: "0x99de131ff1223c4f47316c0bb50e42f356dafdaa",
+      chain: zora,
+      tokenId: "2",
+    }),
+  },
+  {
+    src: "https://remote-image.decentralized-content.com/image?url=https%3A%2F%2Fipfs.decentralized-content.com%2Fipfs%2Fbafybeiegrnialwu66u3nwzkn4gik4i2x2h4ip7y3w2dlymzlpxb5lrqbom&w=1920&q=75",
+    tokenUrl: getTokenUrl({
+      address: "0x060f3edd18c47f59bd23d063bbeb9aa4a8fec6df",
+      chain: zora,
+      tokenId: "1",
+    }),
+  },
+  {
+    src: "https://remote-image.decentralized-content.com/image?url=https%3A%2F%2Fipfs.decentralized-content.com%2Fipfs%2Fbafybeidc6e5t3qmyckqh4fr2ewrov5asmeuv4djycopvo3ro366nd3bfpu&w=1920&q=75",
+    tokenUrl: getTokenUrl({
+      address: "0x8f5ed2503b71e8492badd21d5aaef75d65ac0042",
+      chain: zora,
+      tokenId: "3",
+    }),
+  },
+];
+const initialState: State = { pageIndex: 0 };
+
+const reducer: FrameReducer<State> = (state, action) => {
+  const buttonIndex = action.postBody?.untrustedData.buttonIndex;
+
+  return {
+    pageIndex: buttonIndex
+      ? (state.pageIndex + (buttonIndex === 2 ? 1 : -1)) % nfts.length
+      : state.pageIndex,
+  };
+};
+
+// This is a react server component only
+export default async function Home({
+  params,
+  searchParams,
+}: NextServerPageProps) {
+  const previousFrame = getPreviousFrame<State>(searchParams);
+  const [state] = useFramesReducer<State>(reducer, initialState, previousFrame);
+
+  // then, when done, return next frame
+  return (
+    <div>
+      Mint button example <Link href="/debug">Debug</Link>
+      <FrameContainer
+        pathname="/examples/mint-button"
+        postUrl="/examples/mint-button/frames"
+        state={state}
+        previousFrame={previousFrame}
+      >
+        <FrameImage
+          src={nfts[state.pageIndex]!.src}
+          aspectRatio="1:1"
+        ></FrameImage>
+        <FrameButton>←</FrameButton>
+        <FrameButton>→</FrameButton>
+        <FrameButton action="mint" target={nfts[state.pageIndex]!.tokenUrl}>
+          Mint
+        </FrameButton>
+      </FrameContainer>
+    </div>
+  );
+}

--- a/examples/framesjs-starter/app/page.tsx
+++ b/examples/framesjs-starter/app/page.tsx
@@ -5,13 +5,12 @@ import {
   FrameInput,
   FrameReducer,
   NextServerPageProps,
+  getFrameMessage,
   getPreviousFrame,
   useFramesReducer,
-  getFrameMessage,
 } from "frames.js/next/server";
 import Link from "next/link";
 import { DEBUG_HUB_OPTIONS } from "./debug/constants";
-import { getTokenUrl } from "frames.js";
 
 type State = {
   active: string;
@@ -90,7 +89,7 @@ export default async function Home({
         previousFrame={previousFrame}
       >
         {/* <FrameImage src="https://framesjs.org/og.png" /> */}
-        <FrameImage>
+        <FrameImage aspectRatio="1.91:1">
           <div tw="w-full h-full bg-slate-700 text-white justify-center items-center">
             {frameMessage?.inputText ? frameMessage.inputText : "Hello world"}
           </div>
@@ -101,16 +100,6 @@ export default async function Home({
         </FrameButton>
         <FrameButton>
           {state?.active === "2" ? "Active" : "Inactive"}
-        </FrameButton>
-        <FrameButton
-          action="mint"
-          target={getTokenUrl({
-            address: "0x060f3edd18c47f59bd23d063bbeb9aa4a8fec6df",
-            tokenId: "123",
-            chainId: 7777777,
-          })}
-        >
-          Mint
         </FrameButton>
         <FrameButton action="link" target={`https://www.google.com`}>
           External


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Removes the mint button from the frames.js starter page because it breaks rendering in warpcast (see thread: https://warpcast.com/stephancill/0xbed7a00f)

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [ ] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
