### PR TITLE
feat: add validation for image data uri length

### DIFF
--- a/.changeset/mighty-years-sleep.md
+++ b/.changeset/mighty-years-sleep.md
@@ -1,0 +1,6 @@
+---
+"framesjs-starter": patch
+"frames.js": patch
+---
+
+feat: validate frame image data uri length in debugger

--- a/examples/framesjs-starter/app/debug/components/frame-render.tsx
+++ b/examples/framesjs-starter/app/debug/components/frame-render.tsx
@@ -24,7 +24,16 @@ export function FrameRender({
     <div style={{ width: "382px" }}>
       <img
         src={frame.image}
-        alt="Description of the image"
+        title={
+          frame.image?.startsWith("data:")
+            ? `Frame image: ${Math.ceil(Buffer.from(frame.image).length / 1024)}kb`
+            : "No image"
+        }
+        alt={
+          frame.image?.startsWith("data:")
+            ? `Frame image: ${Math.ceil(Buffer.from(frame.image).length / 1024)}kb`
+            : "No image"
+        }
         style={{ borderRadius: "4px", border: "1px solid #ccc" }}
         {...((frame.imageAspectRatio ?? "1.91:1") === "1:1"
           ? { width: 382, height: 382 }

--- a/packages/frames.js/src/validateFrame.ts
+++ b/packages/frames.js/src/validateFrame.ts
@@ -243,6 +243,14 @@ export function validateFrame({
         key: "fc:frame:image",
       });
     }
+
+    // validate data url is less than 256kb (warpcast)
+    if (getByteLength(image) > 256 * 1024) {
+      addError({
+        message: `Data URI is more than 256kb (${Math.ceil(getByteLength(image) / 1024)}kb)`,
+        key: "fc:frame:image",
+      });
+    }
   }
 
   if (


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Adds validation for data URI length

<img width="1006" alt="Screenshot 2024-02-14 at 21 58 46" src="https://github.com/framesjs/frames.js/assets/5469870/3d6c9bb1-8038-419f-8ffb-22913ca60346">

<img width="713" alt="Screenshot 2024-02-14 at 21 59 09" src="https://github.com/framesjs/frames.js/assets/5469870/f061397b-4bdf-4cd2-8698-53b7803f8add">


## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
