### PR TITLE
feat: get all verified addresses instead

### DIFF
--- a/packages/frames.js/.changeset/mean-bags-cry.md
+++ b/packages/frames.js/.changeset/mean-bags-cry.md
@@ -1,0 +1,5 @@
+---
+"frames.js": minor
+---
+
+feat: Breaking change! `getAddressForFid` renamed to `getAddressesfForFid` and will return all verified addresses rather than just the first one. `validateFrameMessaage` also returns all verified addresses

--- a/packages/frames.js/src/getAddressesForFid.test.ts
+++ b/packages/frames.js/src/getAddressesForFid.test.ts
@@ -1,21 +1,21 @@
-import { getAddressForFid } from ".";
+import { getAddressesForFid } from ".";
 
 describe("getAddressForFid", () => {
   it("should get address for fid with connected address", async () => {
     const fid = 1689;
-    const address = await getAddressForFid({ fid });
+    const address = await getAddressesForFid({ fid });
     expect(address).not.toBe(null);
   });
 
   it("should return null for fid without connected address", async () => {
     const fid = 1;
-    const address = await getAddressForFid({ fid });
+    const address = await getAddressesForFid({ fid });
     expect(address).not.toBe(null);
   });
 
   it("should fall back to custody address if specified", async () => {
     const fid = 1;
-    const address = await getAddressForFid({
+    const address = await getAddressesForFid({
       fid,
       options: { fallbackToCustodyAddress: true },
     });

--- a/packages/frames.js/src/getFrameMessage.ts
+++ b/packages/frames.js/src/getFrameMessage.ts
@@ -5,7 +5,7 @@ import {
   FrameActionDataParsedAndHubContext,
   FrameActionPayload,
   HubHttpUrlOptions,
-  getAddressForFid,
+  getAddressesForFid,
   getUserDataForFid,
   normalizeCastId,
   validateFrameMessage,
@@ -87,13 +87,13 @@ export async function getFrameMessage<T extends GetFrameMessageOptions>(
         `${hubHttpUrl}/v1/reactionById?fid=${requesterFid}&reaction_type=2&target_fid=${castId?.fid}&target_hash=${castId?.hash}`,
         hubRequestOptions
       ).then((res) => res.ok),
-      getAddressForFid({
+      getAddressesForFid({
         fid: requesterFid,
         options: {
           hubHttpUrl,
           hubRequestOptions,
         },
-      }),
+      }) as Promise<string[] | null>,
       getUserDataForFid({
         fid: requesterFid,
         options: {
@@ -111,7 +111,7 @@ export async function getFrameMessage<T extends GetFrameMessageOptions>(
       likedCast,
       recastedCast,
       requesterVerifiedAddresses: requesterVerifiedAddresses
-        ? [requesterVerifiedAddresses]
+        ? requesterVerifiedAddresses
         : [],
       requesterUserData,
     };

--- a/packages/frames.js/src/index.ts
+++ b/packages/frames.js/src/index.ts
@@ -1,4 +1,4 @@
-export * from "./getAddressForFid";
+export * from "./getAddressesForFid";
 export * from "./getUserDataForFid";
 export * from "./getFrame";
 export * from "./getFrameHtml";

--- a/packages/frames.js/src/next/server.tsx
+++ b/packages/frames.js/src/next/server.tsx
@@ -28,7 +28,6 @@ import {
   PreviousFrame,
   RedirectMap,
   RedirectHandler,
-  FrameButtonMintProvidedProps,
 } from "./types";
 export * from "./types";
 
@@ -460,7 +459,7 @@ export async function FrameImage(
     | {
         /** Children to pass to satori to render to PNG. [Supports tailwind](https://vercel.com/blog/introducing-vercel-og-image-generation-fast-dynamic-social-card-images#tailwind-css-support) via the `tw=` prop instead of `className` */
         children: React.ReactNode;
-        options?: SatoriOptions;
+        options?: Partial<SatoriOptions>;
       }
   )
 ) {


### PR DESCRIPTION
## Change Summary

`validateFrameMessage` and `getAddressForFid` only return a single verified address, even if there are many. This changeset now gets all verified addresses from the hub, if possible.

Also tweaked a couple of types

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
