### PR TITLE
Fix: dont show frame on non home routes

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -4,17 +4,17 @@ description: "Frames.js is the react based framework for making frames. Debugger
 ---
 
 <meta property="og:type" content="website" />
-      <meta name="fc:frame" content="vNext" />
-      <meta
-        name="fc:frame:post_url"
-        content="https://framesjs-homeframe.vercel.app/frames?p=&amp;s=%7B%22page%22%3A1%7D&amp;r=%7B%7D"
-      />
-      <meta name="fc:frame:image" content="https://framesjs.org/og.png" />
-      <meta property="og:image" content="https://framesjs.org/og.png" />
-      <meta name="fc:frame:button:1:target" content="https://framesjs.org" />
-      <meta name="fc:frame:button:1:action" content="link" />
-      <meta name="fc:frame:button:2" content="→" />
-      <meta name="fc:frame:button:2:action" content="post" />
+<meta name="fc:frame" content="vNext" />
+<meta
+  name="fc:frame:post_url"
+  content="https://framesjs-homeframe.vercel.app/frames?p=&amp;s=%7B%22page%22%3A1%7D&amp;r=%7B%7D"
+/>
+<meta name="fc:frame:image" content="https://framesjs.org/og.png" />
+<meta property="og:image" content="https://framesjs.org/og.png" />
+<meta name="fc:frame:button:1:target" content="https://framesjs.org" />
+<meta name="fc:frame:button:1:action" content="link" />
+<meta name="fc:frame:button:2" content="→" />
+<meta name="fc:frame:button:2:action" content="post" />
 
 import { HomePage } from "vocs/components";
 

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -3,6 +3,19 @@ title: "Frames.js - fastest way to build Frames"
 description: "Frames.js is the react based framework for making frames. Debugger included."
 ---
 
+<meta property="og:type" content="website" />
+      <meta name="fc:frame" content="vNext" />
+      <meta
+        name="fc:frame:post_url"
+        content="https://framesjs-homeframe.vercel.app/frames?p=&amp;s=%7B%22page%22%3A1%7D&amp;r=%7B%7D"
+      />
+      <meta name="fc:frame:image" content="https://framesjs.org/og.png" />
+      <meta property="og:image" content="https://framesjs.org/og.png" />
+      <meta name="fc:frame:button:1:target" content="https://framesjs.org" />
+      <meta name="fc:frame:button:1:action" content="link" />
+      <meta name="fc:frame:button:2" content="→" />
+      <meta name="fc:frame:button:2:action" content="post" />
+
 import { HomePage } from "vocs/components";
 
 <HomePage.Root>
@@ -32,12 +45,6 @@ Run to clone the starter into a new folder called `framesjs-starter`
 npx degit github:framesjs/frames.js/examples/framesjs-starter#main framesjs-starter
 ```
 or [clone from github](https://github.com/framesjs/frames.js/tree/main/examples/framesjs-starter)
-
-## Recent Updates
-
-- v0.2.0 [Feb 6th]: Supports new action type "link" natively via `<FrameButton href="...">`
-- v0.1.1 [Feb 6th]: Add `getFrameMessage`
-- v0.1.0 [Feb 5th]: New Debugger, `getFrame` signature changes
 
 ## Alternatively, add frames.js to your existing project manually
 

--- a/docs/vocs.config.tsx
+++ b/docs/vocs.config.tsx
@@ -118,18 +118,6 @@ export default defineConfig({
     <>
       {/** on production this is rewritten by vercel */}
       <script defer src="/_vercel/insights/script.js" />
-      <meta property="og:type" content="website" />
-      <meta name="fc:frame" content="vNext" />
-      <meta
-        name="fc:frame:post_url"
-        content="https://framesjs-homeframe.vercel.app/frames?p=&amp;s=%7B%22page%22%3A1%7D&amp;r=%7B%7D"
-      />
-      <meta name="fc:frame:image" content="https://framesjs.org/og.png" />
-      <meta property="og:image" content="https://framesjs.org/og.png" />
-      <meta name="fc:frame:button:1:target" content="https://framesjs.org" />
-      <meta name="fc:frame:button:1:action" content="link" />
-      <meta name="fc:frame:button:2" content="→" />
-      <meta name="fc:frame:button:2:action" content="post" />
     </>
   ),
   sidebar: sidebar,


### PR DESCRIPTION
## Change Summary

- linking to a specific doc page is broken atm. The fix renders it into the page body since vocs abstractions don't support rendering into head

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [ ] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
