### PR TITLE
fix: correctly parse protobuf messages and return eth addresses as string

### DIFF
--- a/.changeset/dry-socks-decide.md
+++ b/.changeset/dry-socks-decide.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix: correctly parse protobuf messages and return eth addresses as string

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "publish-packages": "turbo run build lint && changeset version && changeset publish && git push --follow-tags origin main",
     "publish-canary": "turbo run build lint && cd ./packages/frames.js && yarn publish --tag canary && git push --follow-tags origin main",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
-    "update:proto": "curl https://raw.githubusercontent.com/farcasterxyz/hub-monorepo/main/packages/core/src/protobufs/generated/message.ts -o packages/frames.js/src/farcaster/generated/message.ts"
+    "update:proto": "curl https://raw.githubusercontent.com/farcasterxyz/hub-monorepo/main/packages/core/src/protobufs/generated/message.ts -o packages/frames.js/src/farcaster/generated/message.ts",
+    "test": "jest --watch"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",

--- a/packages/frames.js/jest.config.js
+++ b/packages/frames.js/jest.config.js
@@ -1,5 +1,5 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
-module.exports = {
+export default {
   preset: "ts-jest",
   testEnvironment: "node",
   transform: {

--- a/packages/frames.js/src/farcaster/generated/message.ts
+++ b/packages/frames.js/src/farcaster/generated/message.ts
@@ -511,6 +511,8 @@ export interface FrameActionBody {
     | undefined;
   /** Text input from the user, if present */
   inputText: Uint8Array;
+  /** Serialized frame state value */
+  state: Uint8Array;
 }
 
 function createBaseMessage(): Message {
@@ -1767,7 +1769,13 @@ export const LinkBody = {
 };
 
 function createBaseFrameActionBody(): FrameActionBody {
-  return { url: new Uint8Array(), buttonIndex: 0, castId: undefined, inputText: new Uint8Array() };
+  return {
+    url: new Uint8Array(),
+    buttonIndex: 0,
+    castId: undefined,
+    inputText: new Uint8Array(),
+    state: new Uint8Array(),
+  };
 }
 
 export const FrameActionBody = {
@@ -1783,6 +1791,9 @@ export const FrameActionBody = {
     }
     if (message.inputText.length !== 0) {
       writer.uint32(34).bytes(message.inputText);
+    }
+    if (message.state.length !== 0) {
+      writer.uint32(42).bytes(message.state);
     }
     return writer;
   },
@@ -1822,6 +1833,13 @@ export const FrameActionBody = {
 
           message.inputText = reader.bytes();
           continue;
+        case 5:
+          if (tag != 42) {
+            break;
+          }
+
+          message.state = reader.bytes();
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -1837,6 +1855,7 @@ export const FrameActionBody = {
       buttonIndex: isSet(object.buttonIndex) ? Number(object.buttonIndex) : 0,
       castId: isSet(object.castId) ? CastId.fromJSON(object.castId) : undefined,
       inputText: isSet(object.inputText) ? bytesFromBase64(object.inputText) : new Uint8Array(),
+      state: isSet(object.state) ? bytesFromBase64(object.state) : new Uint8Array(),
     };
   },
 
@@ -1848,6 +1867,8 @@ export const FrameActionBody = {
     message.castId !== undefined && (obj.castId = message.castId ? CastId.toJSON(message.castId) : undefined);
     message.inputText !== undefined &&
       (obj.inputText = base64FromBytes(message.inputText !== undefined ? message.inputText : new Uint8Array()));
+    message.state !== undefined &&
+      (obj.state = base64FromBytes(message.state !== undefined ? message.state : new Uint8Array()));
     return obj;
   },
 
@@ -1863,6 +1884,7 @@ export const FrameActionBody = {
       ? CastId.fromPartial(object.castId)
       : undefined;
     message.inputText = object.inputText ?? new Uint8Array();
+    message.state = object.state ?? new Uint8Array();
     return message;
   },
 };

--- a/packages/frames.js/src/getAddressForFid.test.ts
+++ b/packages/frames.js/src/getAddressForFid.test.ts
@@ -62,6 +62,116 @@ describe("getAddressForFid", () => {
     );
   });
 
+  it("returns fallback if account has only solana address", async () => {
+    nock(DEFAULT_HUB_API_URL)
+      .get("/v1/verificationsByFid?fid=1")
+      .once()
+      .reply(200, {
+        messages: [
+          {
+            data: {
+              type: "MESSAGE_TYPE_VERIFICATION_ADD_ETH_ADDRESS",
+              fid: 1689,
+              timestamp: 76062607,
+              network: "FARCASTER_NETWORK_MAINNET",
+              verificationAddAddressBody: {
+                address: "0x8d25687829d6b85d9e0020b8c89e3ca24de20a89",
+                claimSignature:
+                  "mv4NA1rr3/ktD2h+FFOhT1biC8iWQfRzg4ekqJDYa986ZtGrpfdrAw9boHmb10KecVdMBHt3cVYWwGihgouzYxs=",
+                blockHash:
+                  "0xa4233cb5b9127770c13d5e0d1ea3d1b3e8a4552ea29c956a72d7a1139c76b4c0",
+                verificationType: 0,
+                chainId: 0,
+                protocol: "PROTOCOL_SOLANA",
+                ethSignature:
+                  "mv4NA1rr3/ktD2h+FFOhT1biC8iWQfRzg4ekqJDYa986ZtGrpfdrAw9boHmb10KecVdMBHt3cVYWwGihgouzYxs=",
+              },
+              verificationAddSolAddressBody: {
+                address: "0x8d25687829d6b85d9e0020b8c89e3ca24de20a89",
+                claimSignature:
+                  "mv4NA1rr3/ktD2h+FFOhT1biC8iWQfRzg4ekqJDYa986ZtGrpfdrAw9boHmb10KecVdMBHt3cVYWwGihgouzYxs=",
+                blockHash:
+                  "0xa4233cb5b9127770c13d5e0d1ea3d1b3e8a4552ea29c956a72d7a1139c76b4c0",
+                verificationType: 0,
+                chainId: 0,
+                protocol: "PROTOCOL_SOLANA",
+                ethSignature:
+                  "mv4NA1rr3/ktD2h+FFOhT1biC8iWQfRzg4ekqJDYa986ZtGrpfdrAw9boHmb10KecVdMBHt3cVYWwGihgouzYxs=",
+              },
+            },
+            hash: "0x350b19e5d0f4756303a7e342f9aceb124f0c1a44",
+            hashScheme: "HASH_SCHEME_BLAKE3",
+            signature:
+              "cS01Dr8F+cVb1sYaM8O5rUOhp3QWc36qSXZnZzy1UTNGGxRNS+81iS0CkMJljQNMfHmGDQS6EfWMAIXmOqWuDg==",
+            signatureScheme: "SIGNATURE_SCHEME_ED25519",
+            signer:
+              "0xa5f666cac97ae9f09f78cfaaa624ea2a1f03f042aa87c955d0113275e54e9cfe",
+          },
+        ],
+      });
+
+    const fid = 1;
+
+    await expect(getAddressForFid({ fid })).resolves.toBe(
+      "0x8773442740C17C9d0F0B87022c722F9a136206eD"
+    );
+  });
+
+  it("returns null if account has only solana address and fallback is disabled", async () => {
+    nock(DEFAULT_HUB_API_URL)
+      .get("/v1/verificationsByFid?fid=1")
+      .once()
+      .reply(200, {
+        messages: [
+          {
+            data: {
+              type: "MESSAGE_TYPE_VERIFICATION_ADD_ETH_ADDRESS",
+              fid: 1689,
+              timestamp: 76062607,
+              network: "FARCASTER_NETWORK_MAINNET",
+              verificationAddAddressBody: {
+                address: "0x8d25687829d6b85d9e0020b8c89e3ca24de20a89",
+                claimSignature:
+                  "mv4NA1rr3/ktD2h+FFOhT1biC8iWQfRzg4ekqJDYa986ZtGrpfdrAw9boHmb10KecVdMBHt3cVYWwGihgouzYxs=",
+                blockHash:
+                  "0xa4233cb5b9127770c13d5e0d1ea3d1b3e8a4552ea29c956a72d7a1139c76b4c0",
+                verificationType: 0,
+                chainId: 0,
+                protocol: "PROTOCOL_SOLANA",
+                ethSignature:
+                  "mv4NA1rr3/ktD2h+FFOhT1biC8iWQfRzg4ekqJDYa986ZtGrpfdrAw9boHmb10KecVdMBHt3cVYWwGihgouzYxs=",
+              },
+              verificationAddSolAddressBody: {
+                address: "0x8d25687829d6b85d9e0020b8c89e3ca24de20a89",
+                claimSignature:
+                  "mv4NA1rr3/ktD2h+FFOhT1biC8iWQfRzg4ekqJDYa986ZtGrpfdrAw9boHmb10KecVdMBHt3cVYWwGihgouzYxs=",
+                blockHash:
+                  "0xa4233cb5b9127770c13d5e0d1ea3d1b3e8a4552ea29c956a72d7a1139c76b4c0",
+                verificationType: 0,
+                chainId: 0,
+                protocol: "PROTOCOL_SOLANA",
+                ethSignature:
+                  "mv4NA1rr3/ktD2h+FFOhT1biC8iWQfRzg4ekqJDYa986ZtGrpfdrAw9boHmb10KecVdMBHt3cVYWwGihgouzYxs=",
+              },
+            },
+            hash: "0x350b19e5d0f4756303a7e342f9aceb124f0c1a44",
+            hashScheme: "HASH_SCHEME_BLAKE3",
+            signature:
+              "cS01Dr8F+cVb1sYaM8O5rUOhp3QWc36qSXZnZzy1UTNGGxRNS+81iS0CkMJljQNMfHmGDQS6EfWMAIXmOqWuDg==",
+            signatureScheme: "SIGNATURE_SCHEME_ED25519",
+            signer:
+              "0xa5f666cac97ae9f09f78cfaaa624ea2a1f03f042aa87c955d0113275e54e9cfe",
+          },
+        ],
+      });
+
+    const fid = 1;
+
+    await expect(
+      getAddressForFid({ fid, options: { fallbackToCustodyAddress: false } })
+    ).resolves.toBe(null);
+  });
+
   it("returns null for fid without connected address and disabled fallback", async () => {
     nock(DEFAULT_HUB_API_URL)
       .get("/v1/verificationsByFid?fid=1")
@@ -91,7 +201,7 @@ describe("getAddressForFid", () => {
       getAddressForFid({
         fid,
       })
-    ).resolves.not.toBe(null);
+    ).resolves.toBe("0x8773442740C17C9d0F0B87022c722F9a136206eD");
   });
 
   it("falls back to custody address if api returns error JSON response", async () => {
@@ -111,7 +221,7 @@ describe("getAddressForFid", () => {
       getAddressForFid({
         fid,
       })
-    ).resolves.not.toBe(null);
+    ).resolves.toBe("0x8773442740C17C9d0F0B87022c722F9a136206eD");
   });
 
   it("returns null if api returns error JSON response and fallback is disabled", async () => {

--- a/packages/frames.js/src/getAddressForFid.test.ts
+++ b/packages/frames.js/src/getAddressForFid.test.ts
@@ -1,7 +1,6 @@
 import nock from "nock";
 import { getAddressForFid } from ".";
 import { DEFAULT_HUB_API_URL } from "./default";
-import { MessageType } from "./farcaster";
 
 describe("getAddressForFid", () => {
   beforeEach(() => {
@@ -16,21 +15,51 @@ describe("getAddressForFid", () => {
         messages: [
           {
             data: {
-              type: MessageType.VERIFICATION_ADD_ETH_ADDRESS,
+              type: "MESSAGE_TYPE_VERIFICATION_ADD_ETH_ADDRESS",
+              fid: 1689,
+              timestamp: 76062607,
+              network: "FARCASTER_NETWORK_MAINNET",
+              verificationAddAddressBody: {
+                address: "0x8d25687829d6b85d9e0020b8c89e3ca24de20a89",
+                claimSignature:
+                  "mv4NA1rr3/ktD2h+FFOhT1biC8iWQfRzg4ekqJDYa986ZtGrpfdrAw9boHmb10KecVdMBHt3cVYWwGihgouzYxs=",
+                blockHash:
+                  "0xa4233cb5b9127770c13d5e0d1ea3d1b3e8a4552ea29c956a72d7a1139c76b4c0",
+                verificationType: 0,
+                chainId: 0,
+                protocol: "PROTOCOL_ETHEREUM",
+                ethSignature:
+                  "mv4NA1rr3/ktD2h+FFOhT1biC8iWQfRzg4ekqJDYa986ZtGrpfdrAw9boHmb10KecVdMBHt3cVYWwGihgouzYxs=",
+              },
               verificationAddEthAddressBody: {
-                address: Buffer.from(
-                  "0x8d25687829d6b85d9e0020b8c89e3ca24de20a89",
-                  "hex"
-                ),
+                address: "0x8d25687829d6b85d9e0020b8c89e3ca24de20a89",
+                claimSignature:
+                  "mv4NA1rr3/ktD2h+FFOhT1biC8iWQfRzg4ekqJDYa986ZtGrpfdrAw9boHmb10KecVdMBHt3cVYWwGihgouzYxs=",
+                blockHash:
+                  "0xa4233cb5b9127770c13d5e0d1ea3d1b3e8a4552ea29c956a72d7a1139c76b4c0",
+                verificationType: 0,
+                chainId: 0,
+                protocol: "PROTOCOL_ETHEREUM",
+                ethSignature:
+                  "mv4NA1rr3/ktD2h+FFOhT1biC8iWQfRzg4ekqJDYa986ZtGrpfdrAw9boHmb10KecVdMBHt3cVYWwGihgouzYxs=",
               },
             },
+            hash: "0x350b19e5d0f4756303a7e342f9aceb124f0c1a44",
+            hashScheme: "HASH_SCHEME_BLAKE3",
+            signature:
+              "cS01Dr8F+cVb1sYaM8O5rUOhp3QWc36qSXZnZzy1UTNGGxRNS+81iS0CkMJljQNMfHmGDQS6EfWMAIXmOqWuDg==",
+            signatureScheme: "SIGNATURE_SCHEME_ED25519",
+            signer:
+              "0xa5f666cac97ae9f09f78cfaaa624ea2a1f03f042aa87c955d0113275e54e9cfe",
           },
         ],
       });
 
     const fid = 1689;
 
-    await expect(getAddressForFid({ fid })).resolves.not.toBe(null);
+    await expect(getAddressForFid({ fid })).resolves.toBe(
+      "0x8d25687829d6b85d9e0020b8c89e3ca24de20a89"
+    );
   });
 
   it("returns null for fid without connected address and disabled fallback", async () => {

--- a/packages/frames.js/src/getAddressForFid.ts
+++ b/packages/frames.js/src/getAddressForFid.ts
@@ -44,8 +44,15 @@ export async function getAddressForFid<
 
   let address: AddressReturnType<Options> | null = null;
 
-  if (messages && messages.length > 0) {
-    address = extractAddressFromJSONMessage(messages[0]);
+  // find first valid address
+  if (messages) {
+    for (const message of messages) {
+      address = extractAddressFromJSONMessage(message) ?? null;
+
+      if (address) {
+        break;
+      }
+    }
   }
 
   if (!address && fallbackToCustodyAddress) {

--- a/packages/frames.js/src/getAddressForFid.ts
+++ b/packages/frames.js/src/getAddressForFid.ts
@@ -2,7 +2,7 @@ import { createPublicClient, http, parseAbi } from "viem";
 import { optimism } from "viem/chains";
 import { AddressReturnType, HubHttpUrlOptions } from "./types";
 import { DEFAULT_HUB_API_KEY, DEFAULT_HUB_API_URL } from "./default";
-import { Message, MessageType } from "./farcaster";
+import { extractAddressFromJSONMessage } from ".";
 
 /**
  * Returns the first verified address for a given `Farcaster` users `fid` if available, falling back to their account custodyAddress
@@ -40,33 +40,28 @@ export async function getAddressForFid<
       throw new Error(
         `Failed to parse response body as JSON because server hub returned response with status "${response.status}" and body "${await response.clone().text()}"`
       );
-    })) as { messages?: Message[] };
+    })) as { messages?: Record<string, any>[] };
 
-  if (
-    messages?.[0]?.data &&
-    messages[0].data.type === MessageType.VERIFICATION_ADD_ETH_ADDRESS
-  ) {
-    const {
-      data: {
-        // @ts-expect-error this is correct but somehow it is missing in Message definition
-        verificationAddEthAddressBody: { address },
-      },
-    } = messages[0];
-    return address;
-  } else if (fallbackToCustodyAddress) {
-    const publicClient = createPublicClient({
-      transport: http(),
-      chain: optimism,
-    });
-    const address = await publicClient.readContract({
-      abi: parseAbi(["function custodyOf(uint256 fid) view returns (address)"]),
-      // IdRegistry contract address
-      address: "0x00000000fc6c5f01fc30151999387bb99a9f489b",
-      functionName: "custodyOf",
-      args: [BigInt(fid)],
-    });
-    return address;
+  if (!messages || messages.length === 0) {
+    if (fallbackToCustodyAddress) {
+      const publicClient = createPublicClient({
+        transport: http(),
+        chain: optimism,
+      });
+      const address = await publicClient.readContract({
+        abi: parseAbi([
+          "function custodyOf(uint256 fid) view returns (address)",
+        ]),
+        // IdRegistry contract address
+        address: "0x00000000fc6c5f01fc30151999387bb99a9f489b",
+        functionName: "custodyOf",
+        args: [BigInt(fid)],
+      });
+      return address;
+    }
   } else {
-    return null as AddressReturnType<Options>;
+    return extractAddressFromJSONMessage(messages[0]);
   }
+
+  return null as AddressReturnType<Options>;
 }

--- a/packages/frames.js/src/getAddressesForFid.test.ts
+++ b/packages/frames.js/src/getAddressesForFid.test.ts
@@ -1,7 +1,6 @@
 import nock from "nock";
 import { getAddressesForFid } from "./getAddressesForFid";
 import { DEFAULT_HUB_API_URL } from "./default";
-import { MessageType } from "./farcaster";
 
 describe("getAddressesForFid", () => {
   afterEach(() => {
@@ -16,11 +15,42 @@ describe("getAddressesForFid", () => {
         messages: [
           {
             data: {
-              type: MessageType.VERIFICATION_ADD_ETH_ADDRESS,
+              type: "MESSAGE_TYPE_VERIFICATION_ADD_ETH_ADDRESS",
+              fid: 1689,
+              timestamp: 76062607,
+              network: "FARCASTER_NETWORK_MAINNET",
+              verificationAddAddressBody: {
+                address: "0x8d25687829d6b85d9e0020b8c89e3ca24de20a89",
+                claimSignature:
+                  "mv4NA1rr3/ktD2h+FFOhT1biC8iWQfRzg4ekqJDYa986ZtGrpfdrAw9boHmb10KecVdMBHt3cVYWwGihgouzYxs=",
+                blockHash:
+                  "0xa4233cb5b9127770c13d5e0d1ea3d1b3e8a4552ea29c956a72d7a1139c76b4c0",
+                verificationType: 0,
+                chainId: 0,
+                protocol: "PROTOCOL_ETHEREUM",
+                ethSignature:
+                  "mv4NA1rr3/ktD2h+FFOhT1biC8iWQfRzg4ekqJDYa986ZtGrpfdrAw9boHmb10KecVdMBHt3cVYWwGihgouzYxs=",
+              },
               verificationAddEthAddressBody: {
                 address: "0x8d25687829d6b85d9e0020b8c89e3ca24de20a89",
+                claimSignature:
+                  "mv4NA1rr3/ktD2h+FFOhT1biC8iWQfRzg4ekqJDYa986ZtGrpfdrAw9boHmb10KecVdMBHt3cVYWwGihgouzYxs=",
+                blockHash:
+                  "0xa4233cb5b9127770c13d5e0d1ea3d1b3e8a4552ea29c956a72d7a1139c76b4c0",
+                verificationType: 0,
+                chainId: 0,
+                protocol: "PROTOCOL_ETHEREUM",
+                ethSignature:
+                  "mv4NA1rr3/ktD2h+FFOhT1biC8iWQfRzg4ekqJDYa986ZtGrpfdrAw9boHmb10KecVdMBHt3cVYWwGihgouzYxs=",
               },
             },
+            hash: "0x350b19e5d0f4756303a7e342f9aceb124f0c1a44",
+            hashScheme: "HASH_SCHEME_BLAKE3",
+            signature:
+              "cS01Dr8F+cVb1sYaM8O5rUOhp3QWc36qSXZnZzy1UTNGGxRNS+81iS0CkMJljQNMfHmGDQS6EfWMAIXmOqWuDg==",
+            signatureScheme: "SIGNATURE_SCHEME_ED25519",
+            signer:
+              "0xa5f666cac97ae9f09f78cfaaa624ea2a1f03f042aa87c955d0113275e54e9cfe",
           },
         ],
       });
@@ -29,6 +59,7 @@ describe("getAddressesForFid", () => {
 
     await expect(getAddressesForFid({ fid })).resolves.toMatchObject([
       expect.objectContaining({
+        address: "0x8d25687829d6b85d9e0020b8c89e3ca24de20a89",
         type: "verified",
       }),
       expect.objectContaining({

--- a/packages/frames.js/src/getAddressesForFid.test.ts
+++ b/packages/frames.js/src/getAddressesForFid.test.ts
@@ -68,7 +68,62 @@ describe("getAddressesForFid", () => {
     ]);
   });
 
-  it("falls back to custody address if no addresses are connect to fid", async () => {
+  it("falls back to custody address if only solana addresses are connected to fid", async () => {
+    nock(DEFAULT_HUB_API_URL)
+      .get("/v1/verificationsByFid?fid=1")
+      .once()
+      .reply(200, {
+        messages: [
+          {
+            data: {
+              type: "MESSAGE_TYPE_VERIFICATION_ADD_ETH_ADDRESS",
+              fid: 1689,
+              timestamp: 76062607,
+              network: "FARCASTER_NETWORK_MAINNET",
+              verificationAddAddressBody: {
+                address: "0x8d25687829d6b85d9e0020b8c89e3ca24de20a89",
+                claimSignature:
+                  "mv4NA1rr3/ktD2h+FFOhT1biC8iWQfRzg4ekqJDYa986ZtGrpfdrAw9boHmb10KecVdMBHt3cVYWwGihgouzYxs=",
+                blockHash:
+                  "0xa4233cb5b9127770c13d5e0d1ea3d1b3e8a4552ea29c956a72d7a1139c76b4c0",
+                verificationType: 0,
+                chainId: 0,
+                protocol: "PROTOCOL_SOLANA",
+                ethSignature:
+                  "mv4NA1rr3/ktD2h+FFOhT1biC8iWQfRzg4ekqJDYa986ZtGrpfdrAw9boHmb10KecVdMBHt3cVYWwGihgouzYxs=",
+              },
+              verificationAddSolAddressBody: {
+                address: "0x8d25687829d6b85d9e0020b8c89e3ca24de20a89",
+                claimSignature:
+                  "mv4NA1rr3/ktD2h+FFOhT1biC8iWQfRzg4ekqJDYa986ZtGrpfdrAw9boHmb10KecVdMBHt3cVYWwGihgouzYxs=",
+                blockHash:
+                  "0xa4233cb5b9127770c13d5e0d1ea3d1b3e8a4552ea29c956a72d7a1139c76b4c0",
+                verificationType: 0,
+                chainId: 0,
+                protocol: "PROTOCOL_SOLANA",
+                ethSignature:
+                  "mv4NA1rr3/ktD2h+FFOhT1biC8iWQfRzg4ekqJDYa986ZtGrpfdrAw9boHmb10KecVdMBHt3cVYWwGihgouzYxs=",
+              },
+            },
+            hash: "0x350b19e5d0f4756303a7e342f9aceb124f0c1a44",
+            hashScheme: "HASH_SCHEME_BLAKE3",
+            signature:
+              "cS01Dr8F+cVb1sYaM8O5rUOhp3QWc36qSXZnZzy1UTNGGxRNS+81iS0CkMJljQNMfHmGDQS6EfWMAIXmOqWuDg==",
+            signatureScheme: "SIGNATURE_SCHEME_ED25519",
+            signer:
+              "0xa5f666cac97ae9f09f78cfaaa624ea2a1f03f042aa87c955d0113275e54e9cfe",
+          },
+        ],
+      });
+
+    const fid = 1;
+
+    await expect(getAddressesForFid({ fid })).resolves.toMatchObject([
+      expect.objectContaining({ type: "custody" }),
+    ]);
+  });
+
+  it("falls back to custody address if no addresses are connected to fid", async () => {
     nock(DEFAULT_HUB_API_URL)
       .get("/v1/verificationsByFid?fid=1")
       .once()

--- a/packages/frames.js/src/getAddressesForFid.ts
+++ b/packages/frames.js/src/getAddressesForFid.ts
@@ -54,12 +54,21 @@ export async function getAddressesForFid({
     })) as { messages?: Record<string, any>[] };
 
   if (messages) {
-    const verifiedAddresses = messages.map((message) => {
-      return {
-        address: extractAddressFromJSONMessage(message),
-        type: "verified",
-      } as AddressWithType;
-    });
+    const verifiedAddresses = messages
+      .map((message) => {
+        const address = extractAddressFromJSONMessage(message);
+
+        if (!address) {
+          return null;
+        }
+
+        return {
+          address: extractAddressFromJSONMessage(message),
+          type: "verified",
+        } as AddressWithType;
+      })
+      // filter out unsupported addresses
+      .filter((val): val is AddressWithType => val !== null);
     return [...verifiedAddresses, custodyAddress];
   } else {
     return [custodyAddress];

--- a/packages/frames.js/src/getUserDataForFid.test.ts
+++ b/packages/frames.js/src/getUserDataForFid.test.ts
@@ -1,7 +1,6 @@
 import nock from "nock";
 import { getUserDataForFid } from ".";
 import { DEFAULT_HUB_API_URL } from "./default";
-import { FarcasterNetwork, MessageType, UserDataType } from "./farcaster";
 
 describe("getUserDataForFid", () => {
   beforeEach(() => {
@@ -16,48 +15,94 @@ describe("getUserDataForFid", () => {
         messages: [
           {
             data: {
-              type: MessageType.USER_DATA_ADD,
-              fid: 6833,
-              timestamp: 83433831,
-              network: FarcasterNetwork.MAINNET,
+              type: "MESSAGE_TYPE_USER_DATA_ADD",
+              fid: 1214,
+              timestamp: 69403426,
+              network: "FARCASTER_NETWORK_MAINNET",
               userDataBody: {
-                type: UserDataType.PFP,
+                type: "USER_DATA_TYPE_PFP",
                 value:
                   "https://lh3.googleusercontent.com/-S5cdhOpZtJ_Qzg9iPWELEsRTkIsZ7qGYmVlwEORgFB00WWAtZGefRnS4Bjcz5ah40WVOOWeYfU5pP9Eekikb3cLMW2mZQOMQHlWhg",
               },
             },
+            hash: "0x465e44c9d8b4f6189d40b79029168a1dc0b50ea5",
+            hashScheme: "HASH_SCHEME_BLAKE3",
+            signature:
+              "x4J7Lo4FM7wutYYomV7ItFSOlo3Rca4s+BQ5rQK0dvRpIrsCCX7BU5fnkX3UfseXTyh4kJOVYmeEhLeeA27oAw==",
+            signatureScheme: "SIGNATURE_SCHEME_ED25519",
+            signer:
+              "0xf23a5c7b9f067c621a989a585b78daf7b2a9debe9d54325ef95b0878f44204c6",
           },
           {
             data: {
-              type: MessageType.USER_DATA_ADD,
-              fid: 6833,
-              timestamp: 83433831,
-              network: FarcasterNetwork.MAINNET,
+              type: "MESSAGE_TYPE_USER_DATA_ADD",
+              fid: 1214,
+              timestamp: 69403426,
+              network: "FARCASTER_NETWORK_MAINNET",
               userDataBody: {
-                type: UserDataType.BIO,
+                type: "USER_DATA_TYPE_USERNAME",
+                value: "df",
+              },
+            },
+            hash: "0x93d8ce58ad883db4e1f3c1dfc1cc60a12282b79b",
+            hashScheme: "HASH_SCHEME_BLAKE3",
+            signature:
+              "c+vVPGW/IoVe0chBEyLTPdzxqNtRx4IJp74RPMjxRQsZqs/rwlnGkDjxD2ocYS5FNCLH78dfMDAAoqNETaIZBA==",
+            signatureScheme: "SIGNATURE_SCHEME_ED25519",
+            signer:
+              "0xf23a5c7b9f067c621a989a585b78daf7b2a9debe9d54325ef95b0878f44204c6",
+          },
+          {
+            data: {
+              type: "MESSAGE_TYPE_USER_DATA_ADD",
+              fid: 1214,
+              timestamp: 99133426,
+              network: "FARCASTER_NETWORK_MAINNET",
+              userDataBody: {
+                type: "USER_DATA_TYPE_DISPLAY",
+                value: "David Furlong 🎩",
+              },
+            },
+            hash: "0x092dad1a3b31c6ab22ca54607a36c0b2eb09b01f",
+            hashScheme: "HASH_SCHEME_BLAKE3",
+            signature:
+              "c3yG3JfPXOYCskbnlnMwstSn+xUuVs6maZ1T5bgUoDpVEjvJQOnzb4sVz5izIw1D3bmiWl8w5eg0tqkrHY2nBg==",
+            signatureScheme: "SIGNATURE_SCHEME_ED25519",
+            signer:
+              "0xf23a5c7b9f067c621a989a585b78daf7b2a9debe9d54325ef95b0878f44204c6",
+          },
+          {
+            data: {
+              type: "MESSAGE_TYPE_USER_DATA_ADD",
+              fid: 1214,
+              timestamp: 99133426,
+              network: "FARCASTER_NETWORK_MAINNET",
+              userDataBody: {
+                type: "USER_DATA_TYPE_BIO",
                 value:
                   "Building open source software via @frames and /mod, to help Farcaster and decentralized social win",
               },
             },
-          },
-          {
-            data: {
-              type: MessageType.USER_DATA_ADD,
-              fid: 6833,
-              timestamp: 83433831,
-              network: FarcasterNetwork.MAINNET,
-              userDataBody: {
-                type: UserDataType.DISPLAY,
-                value: "David Furlong 🎩",
-              },
-            },
+            hash: "0x4f19c63377605ca2d8e8ce7fd51825969472732a",
+            hashScheme: "HASH_SCHEME_BLAKE3",
+            signature:
+              "eTEEM300pXvzvGKgsZQXMBkK2q5YQ2adwfwa/3lBvkocJQBWKXnOad3dcruXcc/kerKPDJgx81dDm3xmLgF7AQ==",
+            signatureScheme: "SIGNATURE_SCHEME_ED25519",
+            signer:
+              "0xf23a5c7b9f067c621a989a585b78daf7b2a9debe9d54325ef95b0878f44204c6",
           },
         ],
       });
 
     const fid = 1214;
 
-    await expect(getUserDataForFid({ fid })).resolves.not.toBe(null);
+    await expect(getUserDataForFid({ fid })).resolves.toMatchObject({
+      displayName: "David Furlong 🎩",
+      bio: "Building open source software via @frames and /mod, to help Farcaster and decentralized social win",
+      username: "df",
+      profileImage:
+        "https://lh3.googleusercontent.com/-S5cdhOpZtJ_Qzg9iPWELEsRTkIsZ7qGYmVlwEORgFB00WWAtZGefRnS4Bjcz5ah40WVOOWeYfU5pP9Eekikb3cLMW2mZQOMQHlWhg",
+    });
   });
 
   it("returns null for invalid fid", async () => {

--- a/packages/frames.js/src/getUserDataForFid.ts
+++ b/packages/frames.js/src/getUserDataForFid.ts
@@ -36,11 +36,11 @@ export async function getUserDataForFid<
       throw new Error(
         `Failed to parse response body as JSON because server hub returned response with status "${userDataResponse.status}" and body "${await userDataResponse.clone().text()}"`
       );
-    })) as { messages?: Message[] };
+    })) as { messages?: Record<string, any>[] };
 
   if (messages && messages.length > 0) {
     const valuesByType = messages.reduce(
-      (acc, messageJson: Message) => {
+      (acc, messageJson) => {
         const message = Message.fromJSON(messageJson);
 
         if (message.data?.type !== MessageType.USER_DATA_ADD) {

--- a/packages/frames.js/src/utils.ts
+++ b/packages/frames.js/src/utils.ts
@@ -1,4 +1,4 @@
-import { CastId, Message } from "./farcaster";
+import { CastId, Message, MessageData, MessageType } from "./farcaster";
 import {
   FrameActionPayload,
   FrameButton,
@@ -80,4 +80,60 @@ export function isValidVersion(version: string): boolean {
   }
 
   return true;
+}
+
+export function getEnumKeyByEnumValue<
+  TEnumKey extends string,
+  TEnumVal extends string | number,
+>(
+  enumDefinition: { [key in TEnumKey]: TEnumVal },
+  enumValue: TEnumVal
+): string {
+  return (
+    Object.keys(enumDefinition)[
+      Object.values(enumDefinition).indexOf(enumValue)
+    ] ?? ""
+  );
+}
+
+export function extractAddressFromJSONMessage(message: any): `0x${string}` {
+  const { data } = Message.fromJSON(message);
+
+  if (!data) {
+    throw new Error("Invalid message provided. Message data is missing");
+  }
+
+  if (data.type !== MessageType.VERIFICATION_ADD_ETH_ADDRESS) {
+    throw new Error(
+      `Invalid message provided. Expected message type to be ${MessageType.VERIFICATION_ADD_ETH_ADDRESS} but got ${getEnumKeyByEnumValue(MessageType, data.type)}.`
+    );
+  }
+
+  if (
+    !data.verificationAddAddressBody &&
+    // this is not defined on protobuf but just in case
+    !(data as any).verificationAddEthAddressBody
+  ) {
+    throw new Error(
+      "Invalid message provided. Message data is missing verificationAddAddressBody or verificationAddEthAddressBody"
+    );
+  }
+
+  let address: `0x${string}`;
+
+  if (data.verificationAddAddressBody) {
+    address = message.data.verificationAddAddressBody.address;
+  } else {
+    address = (data as any).verificationAddEthAddressBody.address;
+  }
+
+  /**
+   * This is ugly hack but we want to return the address as a string that is expected by the users ( essentially what they see in the response from the hub ).
+   * We could use Buffer.from(data.verificationAddAddressBody.address).toString('base64') here but that results in different base64.
+   * Therefore we return address from source message and not from decoded message.
+   *
+   * For example for value 0x8d25687829d6b85d9e0020b8c89e3ca24de20a89 from API we get 0x8d25687829d6b85d9e0020b8c89e3ca24de20a8w== from Buffer.from(...).toString('base64').
+   * The values are the same if you compare them as Buffer.from(a).equals(Buffer.from(b)).
+   */
+  return address;
 }

--- a/packages/frames.js/src/utils.ts
+++ b/packages/frames.js/src/utils.ts
@@ -1,4 +1,4 @@
-import { CastId, Message, MessageData, MessageType } from "./farcaster";
+import { CastId, Message, MessageType } from "./farcaster";
 import {
   FrameActionPayload,
   FrameButton,


### PR DESCRIPTION
## Change Summary

This PR fixes parsing messages from JSON to protobuf representation. And handles eth addresses properly.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
