### PR TITLE
fix: proxy SSL version error

### DIFF
--- a/.changeset/dry-socks-decide.md
+++ b/.changeset/dry-socks-decide.md
@@ -1,5 +1,0 @@
----
-"frames.js": patch
----
-
-fix: correctly parse protobuf messages and return eth addresses as string

--- a/.changeset/fluffy-bottles-matter.md
+++ b/.changeset/fluffy-bottles-matter.md
@@ -1,5 +1,0 @@
----
-"frames.js": patch
----
-
-fix: correctly export types and commonjs/es modules

--- a/.changeset/friendly-panthers-fly.md
+++ b/.changeset/friendly-panthers-fly.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix: SSL proxy version error

--- a/.changeset/friendly-panthers-fly.md
+++ b/.changeset/friendly-panthers-fly.md
@@ -2,4 +2,4 @@
 "frames.js": patch
 ---
 
-fix: SSL proxy version error
+fix: SSL proxy version error by using `NEXT_PUBLIC_HOST` for redirects in `next/server`

--- a/packages/debugger/README.md
+++ b/packages/debugger/README.md
@@ -38,3 +38,7 @@ const frameMessage = await getFrameMessage(previousFrame.postBody, {
   hubHttpUrl: "http://localhost:3010/hub",
 });
 ```
+
+```
+
+```

--- a/packages/debugger/README.md
+++ b/packages/debugger/README.md
@@ -38,7 +38,3 @@ const frameMessage = await getFrameMessage(previousFrame.postBody, {
   hubHttpUrl: "http://localhost:3010/hub",
 });
 ```
-
-```
-
-```

--- a/packages/frames.js/CHANGELOG.md
+++ b/packages/frames.js/CHANGELOG.md
@@ -1,5 +1,12 @@
 # frames.js
 
+## 0.5.3
+
+### Patch Changes
+
+- 244d35b: fix: correctly parse protobuf messages and return eth addresses as string
+- b22ad38: fix: correctly export types and commonjs/es modules
+
 ## 0.5.2
 
 ### Patch Changes

--- a/packages/frames.js/package.json
+++ b/packages/frames.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frames.js",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "type": "module",
   "main": "./dist/index.cjs",
   "types": "index.d.cts",


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
This is an alternative for #121 which doesn't require an extra param to be passed to the exported POST request and uses next.js headers to derive that info instead.

Fixes https://linear.app/modprotocol/issue/FRA-49/issues-with-docker
Closes #121 

h/t @cryptods8 for their gist which details the solution: https://gist.github.com/cryptods8/8fbfb9d5da246bc65c1292212c476ae3

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
