### PR TITLE
Fix NEXT_PUBLIC_HOST env variable setup

### DIFF
--- a/examples/framesjs-starter/scripts/dev-script.js
+++ b/examples/framesjs-starter/scripts/dev-script.js
@@ -9,7 +9,7 @@ if (!process.env.FJS_MONOREPO) {
   args = [
     "--kill-others",
     '"next dev"',
-    `"${process.env.FARCASTER_DEVELOPER_MNEMONIC ? `FARCASTER_DEVELOPER_MNEMONIC=${process.env.FARCASTER_DEVELOPER_MNEMONIC}` : ""} ${process.env.FARCASTER_DEVELOPER_FID ? `FARCASTER_DEVELOPER_FID=${process.env.FARCASTER_DEVELOPER_FID}` : ""} frames ${process.env.NEXT_PUBLIC_HOST ? "--url ${process.env.NEXT_PUBLIC_HOST}" : ""}  "`,
+    `"${process.env.FARCASTER_DEVELOPER_MNEMONIC ? `FARCASTER_DEVELOPER_MNEMONIC=${process.env.FARCASTER_DEVELOPER_MNEMONIC}` : ""} ${process.env.FARCASTER_DEVELOPER_FID ? `FARCASTER_DEVELOPER_FID=${process.env.FARCASTER_DEVELOPER_FID}` : ""} frames ${process.env.NEXT_PUBLIC_HOST ? `--url ${process.env.NEXT_PUBLIC_HOST}` : ""}  "`,
   ];
 }
 


### PR DESCRIPTION
## Change Summary

When running "yarn dev" with the latest version of the starter there was a bad substitution error because of the way in which the NEXT_PUBLIC_HOST was passed to the "dev-script.js" file.

I changed it to have the correct substitution.
