### PR TITLE
fix: render fetch url params

### DIFF
--- a/.changeset/nervous-wolves-flash.md
+++ b/.changeset/nervous-wolves-flash.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix: render frame url params fetching

--- a/packages/frames.js/src/render/use-frame.tsx
+++ b/packages/frames.js/src/render/use-frame.tsx
@@ -134,7 +134,8 @@ export function useFrame<
 
       let requestError: unknown | null = null;
       let newFrame: ReturnType<typeof getFrame> | null = null;
-      const proxiedUrl = `${frameGetProxy}?url=${url}`;
+      const searchParams = new URLSearchParams({ url });
+      const proxiedUrl = `${frameGetProxy}?${searchParams.toString()}`;
 
       let stackItem: FramesStack[number];
       let response;


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Fixes an issue where url params were not being passed to the frame fetch proxy correctly.

https://warpcast.com/ds8/0x6b50c49e

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
