### PR TITLE
fix: mock hub only dev

### DIFF
--- a/.changeset/plenty-weeks-work.md
+++ b/.changeset/plenty-weeks-work.md
@@ -1,0 +1,5 @@
+---
+"framesjs-starter": patch
+---
+
+fix: only use mock hub url in development

--- a/examples/framesjs-starter/app/debug.ts
+++ b/examples/framesjs-starter/app/debug.ts
@@ -1,10 +1,10 @@
 const DEFAULT_DEBUGGER_URL =
   process.env.DEBUGGER_URL ?? "http://localhost:3010/";
 
-export const DEFAULT_DEBUGGER_HUB_URL = new URL(
-  "/hub",
-  DEFAULT_DEBUGGER_URL
-).toString();
+export const DEFAULT_DEBUGGER_HUB_URL =
+  process.env.NODE_ENV === "development"
+    ? new URL("/hub", DEFAULT_DEBUGGER_URL).toString()
+    : undefined;
 
 export function createDebugUrl(frameURL: string | URL): string {
   const url = new URL("/", DEFAULT_DEBUGGER_URL);


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Mock hub URL should only be available in development to prevent use in production.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
