### PR TITLE
fix: frame UI clear input

### DIFF
--- a/.changeset/lemon-frogs-cover.md
+++ b/.changeset/lemon-frogs-cover.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix: clear FrameUI input after submitting

--- a/packages/frames.js/src/render/frame-ui.tsx
+++ b/packages/frames.js/src/render/frame-ui.tsx
@@ -66,6 +66,7 @@ export function FrameUI({ frameState, theme, FrameImage }: FrameUIProps) {
             borderRadius: `${resolvedTheme.buttonRadius}px`,
             borderColor: `${resolvedTheme.buttonBorderColor}`,
           }}
+          value={frameState.inputText}
           type="text"
           placeholder={frameState.frame.inputText}
           onChange={(e) => frameState.setInputText(e.target.value)}


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Fixes a bug where the frame UI's input would not clear after submitting a frame action by correctly coupling the input text value to the input field.

Fixes #169

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
