### PR TITLE
fix: open frames button index parsing

### DIFF
--- a/.changeset/soft-chairs-return.md
+++ b/.changeset/soft-chairs-return.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix: correctly parse button index of open frames html

--- a/packages/frames.js/src/getFrame.ts
+++ b/packages/frames.js/src/getFrame.ts
@@ -358,7 +358,11 @@ export function getFrame({
 
 export function parseButtonElement(elem: cheerio.Element) {
   const nameAttr = elem.attribs["name"] || elem.attribs["property"];
-  const buttonIndex = nameAttr?.split(":")[3];
+  const buttonSegments = nameAttr?.split(":");
+
+  // Handles both cases of fc:frame:button:N and of:button:N
+  const buttonIndex =
+    buttonSegments?.[0] === "fc" ? buttonSegments?.[3] : buttonSegments?.[2];
   try {
     return {
       buttonIndex: parseInt(buttonIndex || ""),


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Fixes an issue where `of:button:N` would not be correctly parsed due to a hard-coded index that hadn't been updated for parsing `fc:frame:button:N`

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
