### PR TITLE
chore: rename fetchMetadata function

### DIFF
--- a/examples/framesjs-starter/app/examples/new-api/page.tsx
+++ b/examples/framesjs-starter/app/examples/new-api/page.tsx
@@ -2,14 +2,14 @@ import Link from "next/link";
 import { currentURL } from "../../utils";
 import { createDebugUrl } from "../../debug";
 import type { Metadata } from "next";
-import { fetchMetaData } from "@frames.js/next";
+import { fetchMetadata } from "@frames.js/next";
 
 export async function generateMetadata(): Promise<Metadata> {
   return {
     title: "New api example",
     description: "This is a new api example",
     other: {
-      ...(await fetchMetaData(
+      ...(await fetchMetadata(
         new URL(
           "/examples/new-api/frames",
           process.env.VERCEL_URL || "http://localhost:3000"

--- a/examples/framesjs-starter/pages/page-router/index.tsx
+++ b/examples/framesjs-starter/pages/page-router/index.tsx
@@ -1,8 +1,8 @@
 import type { InferGetServerSidePropsType, GetServerSideProps } from "next";
 import Head from "next/head";
 import {
-  fetchMetaData,
-  metaDataToMetaTags,
+  fetchMetadata,
+  metadataToMetaTags,
 } from "@frames.js/next/pages-router";
 import Link from "next/link";
 import { createDebugUrl } from "../../app/debug";
@@ -10,7 +10,7 @@ import { createDebugUrl } from "../../app/debug";
 export const getServerSideProps = async function getServerSideProps() {
   return {
     props: {
-      metadata: await fetchMetaData(
+      metadata: await fetchMetadata(
         new URL(
           "/api/frames",
           process.env.VERCEL_URL || "http://localhost:3000"
@@ -19,7 +19,7 @@ export const getServerSideProps = async function getServerSideProps() {
     },
   };
 } satisfies GetServerSideProps<{
-  metadata: Awaited<ReturnType<typeof fetchMetaData>>;
+  metadata: Awaited<ReturnType<typeof fetchMetadata>>;
 }>;
 
 export default function Page({
@@ -29,7 +29,7 @@ export default function Page({
     <>
       <Head>
         <title>Frames.js app</title>
-        {metaDataToMetaTags(metadata)}
+        {metadataToMetaTags(metadata)}
       </Head>
 
       <div>

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -46,11 +46,11 @@ If you use Next.js App Router and [metadata](https://nextjs.org/docs/app/buildin
 
 ```jsx
 // app/page.jsx
-import { fetchMetaData } from "@frames.js/next";
+import { fetchMetadata } from "@frames.js/next";
 
 export async function generateMetadata() {
   // you must provide full URL to your Frames app so we can fetch meta tags
-  const framesMetaTags = await fetchMetaData(
+  const framesMetaTags = await fetchMetadata(
     new URL("/api", process.env.VERCEL_URL || "http://localhost:3000")
   );
 
@@ -92,19 +92,19 @@ export default framesRouteHandler;
 
 #### Rendering Frames meta tags on existing Next.js page using Pages Router
 
-If you use Next.js Pages Router you can include your Frames meta tags using `fetchMetaData()` and `metaDataToMetaTags()` functions.
+If you use Next.js Pages Router you can include your Frames meta tags using `fetchMetadata()` and `metadataToMetaTags()` functions.
 
 ```jsx
 // pages/index.jsx
 import {
-  fetchmMetaData,
-  metaDataToMetaTags,
+  fetchmMetadata,
+  metadataToMetaTags,
 } from "@frames.js/next/pages-router";
 import Head from "next/head";
 
 export async function getServerSideProps() {
   // you must provide full URL to your Frames app so we can fetch meta tags
-  const framesMetaTags = await fetchMetaData(
+  const framesMetaTags = await fetchMetadata(
     new URL("/api", process.env.VERCEL_URL || "http://localhost:3000")
   );
 
@@ -120,7 +120,7 @@ export default function Home({ framesMetaTags }) {
     <div>
       <Head>
         <title>My Frames</title>
-        {metaDataToMetaTags(framesMetaTags)}
+        {metadataToMetaTags(framesMetaTags)}
       </Head>
       <h1>My page</h1>
     </div>

--- a/packages/next/src/fetchMetaData.test.ts
+++ b/packages/next/src/fetchMetaData.test.ts
@@ -1,8 +1,8 @@
 import nock from "nock";
-import { fetchMetaData } from "./fetchMetaData";
+import { fetchMetadata } from "./fetchMetadata";
 import type { FrameFlattened } from "frames.js";
 
-describe("fetchMetaData", () => {
+describe("fetchMetadata", () => {
   beforeAll(() => {
     nock.disableNetConnect();
   });
@@ -21,7 +21,7 @@ describe("fetchMetaData", () => {
       } satisfies FrameFlattened);
 
     await expect(
-      fetchMetaData(new URL("/frames", "http://localhost:3000"))
+      fetchMetadata(new URL("/frames", "http://localhost:3000"))
     ).resolves.toEqual({
       "fc:frame": "vNext",
       "fc:frame:image": "imageUrl",
@@ -33,7 +33,7 @@ describe("fetchMetaData", () => {
     nock("http://localhost:3000").get("/frames").reply(404);
 
     await expect(
-      fetchMetaData(new URL("/frames", "http://localhost:3000"))
+      fetchMetadata(new URL("/frames", "http://localhost:3000"))
     ).rejects.toThrow(
       "Failed to fetch frames metadata from http://localhost:3000/frames. The server returned 404 Not Found response."
     );

--- a/packages/next/src/fetchMetaData.ts
+++ b/packages/next/src/fetchMetaData.ts
@@ -7,14 +7,14 @@ import { Metadata } from "next";
  *
  * @example
  * import type { Metadata } from "next";
- * import { fetchMetaData } from "@frames.js/next";
+ * import { fetchMetadata } from "@frames.js/next";
  *
  * export async function generateMetadata(): Promise<Metadata> {
  *  return {
  *   title: "New api example",
  *   description: "This is a new api example",
  *   other: {
- *     ...(await fetchMetaData(
+ *     ...(await fetchMetadata(
  *       new URL(
  *        "/examples/new-api/frames",
  *        process.env.VERCEL_URL || "http://localhost:3000"
@@ -25,7 +25,7 @@ import { Metadata } from "next";
  *
  * @param url Full URL of your Frames app
  */
-export async function fetchMetaData(
+export async function fetchMetadata(
   url: URL | string
 ): Promise<NonNullable<Metadata["other"]>> {
   const response = await fetch(url, {

--- a/packages/next/src/index.test.ts
+++ b/packages/next/src/index.test.ts
@@ -1,7 +1,7 @@
 import * as lib from ".";
 
 describe("next adapter", () => {
-  it.each(["Button", "createFrames", "fetchMetaData"])(
+  it.each(["Button", "createFrames", "fetchMetadata"])(
     "exports %s",
     (exportName) => {
       expect(lib).toHaveProperty(exportName);

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1,7 +1,7 @@
 import { createFrames as coreCreateFrames } from "frames.js/core";
 export { Button, type types } from "frames.js/core";
 
-export { fetchMetaData } from "./fetchMetaData";
+export { fetchMetadata } from "./fetchMetadata";
 
 export const createFrames: typeof coreCreateFrames =
   function createFramesForNextJS(options: any) {

--- a/packages/next/src/pages-router.tsx
+++ b/packages/next/src/pages-router.tsx
@@ -4,7 +4,7 @@ export { Button, type types } from "frames.js/core";
 import type { Writable, Readable } from "node:stream";
 import { Stream } from "node:stream";
 
-export { fetchMetaData } from "./fetchMetaData";
+export { fetchMetadata } from "./fetchMetadata";
 
 export const createFrames: typeof coreCreateFrames =
   function createFramesForNextJSPagesRouter(options: any) {
@@ -25,15 +25,15 @@ export const createFrames: typeof coreCreateFrames =
   } as unknown as typeof coreCreateFrames;
 
 /**
- * Converts metadata returned from fetchMetaData() call to Next.js <Head /> compatible components.
+ * Converts metadata returned from fetchMetadata() call to Next.js <Head /> compatible components.
  *
  * @example
- * import { fetchMetaData, metaDataToMetaTags } from "@frames.js/next/pages-router";
+ * import { fetchMetadata, metadataToMetaTags } from "@frames.js/next/pages-router";
  *
  * export const getServerSideProps = async function getServerSideProps() {
  *  return {
  *   props: {
- *    metadata: await fetchMetaData(
+ *    metadata: await fetchMetadata(
  *     new URL("/api", process.env.VERCEL_URL || "http://localhost:3000")
  *    ),
  *  },
@@ -46,13 +46,13 @@ export const createFrames: typeof coreCreateFrames =
  *    <>
  *      <Head>
  *        <title>Frames.js app</title>
- *        {metaDataToMetaTags(metadata)}
+ *        {metadataToMetaTags(metadata)}
  *      </Head>
  *    </>
  *  );
  * }
  */
-export function metaDataToMetaTags(metadata: NonNullable<Metadata["other"]>) {
+export function metadataToMetaTags(metadata: NonNullable<Metadata["other"]>) {
   return (
     <>
       {Object.entries(metadata).map(([key, value]) => {


### PR DESCRIPTION
## Change Summary

This PR changes `fetchMetaData` and `metaDataToMetaTags` function names so they are compatible with remix adapter