### PR TITLE
fix: openframes type inference

### DIFF
--- a/packages/frames.js/src/core/middleware/openframes.test.ts
+++ b/packages/frames.js/src/core/middleware/openframes.test.ts
@@ -205,7 +205,7 @@ describe("openframes middleware", () => {
   });
 
   it("supports custom global typed context", async () => {
-    const mw1 = openframes<{ test1?: boolean }>({
+    const mw1 = openframes({
       clientProtocol: "foo@vNext",
       handler: {
         isValidPayload: () => false,
@@ -214,8 +214,7 @@ describe("openframes middleware", () => {
         },
       },
     });
-    // TODO: Can this be inferred as a partial?
-    const mw2 = openframes<{ test2?: boolean }>({
+    const mw2 = openframes({
       clientProtocol: "bar@vNext",
       handler: {
         isValidPayload: () => true,
@@ -231,7 +230,7 @@ describe("openframes middleware", () => {
 
     const routeHandler = handler(async (ctx) => {
       return {
-        image: `/?test2=${ctx.message?.test2}`,
+        image: `/?test1=${ctx.message?.test1}&test2=${ctx.message?.test2}`,
       };
     });
 
@@ -244,7 +243,7 @@ describe("openframes middleware", () => {
     expect(response).toBeInstanceOf(Response);
 
     const responseText = await response.clone().text();
-    expect(responseText).toContain("/?test2=true");
+    expect(responseText).toContain("/?test1=undefined&test2=true");
   });
 
   it("moves to next middleware if request is POST with valid JSON but invalid body shape", async () => {

--- a/packages/frames.js/src/core/middleware/openframes.ts
+++ b/packages/frames.js/src/core/middleware/openframes.ts
@@ -6,7 +6,7 @@ import { isFrameDefinition } from "../utils";
 type OpenFrameMessage = any;
 
 export type OpenFramesMessageContext<T = OpenFrameMessage> = {
-  message?: T;
+  message?: Partial<T>;
   clientProtocol?: ClientProtocolId;
 };
 

--- a/packages/frames.js/src/core/middleware/openframes.ts
+++ b/packages/frames.js/src/core/middleware/openframes.ts
@@ -3,10 +3,18 @@ import { RequestBodyNotJSONError } from "../errors";
 import { FramesMiddleware, FramesMiddlewareReturnType } from "../types";
 import { isFrameDefinition } from "../utils";
 
-type FramesMessageContext = {
-  // TODO: this should extend a base FrameMessage with common fields
-  message?: any;
-  clientProtocol?: string;
+type OpenFrameMessage = any;
+
+export type OpenFramesMessageContext<T = OpenFrameMessage> = {
+  message?: T;
+  clientProtocol?: ClientProtocolId;
+};
+
+export type ClientProtocolHandler<T = OpenFrameMessage> = {
+  // eslint-disable-next-line no-unused-vars
+  getFrameMessage: (body: JSON) => Promise<T | undefined> | undefined;
+  // eslint-disable-next-line no-unused-vars
+  isValidPayload: (body: JSON) => boolean;
 };
 
 async function cloneJsonBody(request: Request): Promise<JSON | undefined> {
@@ -31,71 +39,65 @@ async function cloneJsonBody(request: Request): Promise<JSON | undefined> {
   }
 }
 
-async function nextInjectClientProtocols({
+async function nextInjectAcceptedClient({
   nextResult,
-  accepts,
+  clientProtocol,
 }: {
   nextResult: FramesMiddlewareReturnType;
-  accepts: ClientProtocolId[];
+  clientProtocol: ClientProtocolId;
 }) {
   const result = await nextResult;
   if (isFrameDefinition(result)) {
-    return { ...result, accepts };
+    return { ...result, accepts: [...(result.accepts || []), clientProtocol] };
   }
   return result;
 }
 
-export function openframes({
-  clientProtocolHandlers: handlers,
+export function openframes<T = OpenFrameMessage>({
+  clientProtocol: clientProtocolRaw,
+  handler,
 }: {
   /**
-   * Validators and handlers for frame messages from different client protocols.
-   * Key is the client protocol ID (e.g. "id@version")
-   * Value is an object containing a frame message validator and handler
+   * Validator and and handler for frame messages from a supported client protocol.
+   * `clientProtocol` is the ID of the client protocol in the form of a ClientProtocolId object or a string of the shape `"id@version"`
+   * Handler is an object containing a frame message validator and handler
    * The output of the handler is added to the context as `message`
    */
-  clientProtocolHandlers: Record<
-    string,
-    {
-      // TODO: better types
-      getFrameMessage: (body: JSON) => Promise<any | undefined> | undefined;
-      isValidPayload: (body: JSON) => Boolean;
-    }
-  >;
-}): FramesMiddleware<FramesMessageContext> {
+  clientProtocol: ClientProtocolId | `${string}@${string}`;
+  handler: ClientProtocolHandler<T>;
+}): FramesMiddleware<OpenFramesMessageContext<T>> {
   return async (context, next) => {
-    const accepts: ClientProtocolId[] = Object.keys(handlers)
-      .map((clientProtocol) => {
-        const [id, version] = clientProtocol.split("@");
-        if (!id || !version) {
-          return undefined;
-        }
-
-        return { id, version };
-      })
-      .filter(Boolean) as ClientProtocolId[];
+    const clientProtocol: ClientProtocolId =
+      typeof clientProtocolRaw === "string"
+        ? {
+            id: clientProtocolRaw.split("@")[0]!,
+            version: clientProtocolRaw.split("@")[1]!,
+          }
+        : clientProtocolRaw;
 
     // frame message is available only if the request is a POST request
     if (context.request.method !== "POST") {
-      return nextInjectClientProtocols({ nextResult: next(), accepts });
+      return nextInjectAcceptedClient({
+        nextResult: next(),
+        clientProtocol: clientProtocol,
+      });
     }
 
     const json = await cloneJsonBody(context.request);
 
     if (!json) {
-      return nextInjectClientProtocols({ nextResult: next(), accepts });
+      return nextInjectAcceptedClient({
+        nextResult: next(),
+        clientProtocol,
+      });
     }
 
-    // Find first handler with key
-    const clientHandler = Object.entries(handlers).find(([, handler]) => {
-      return handler.isValidPayload(json);
-    });
-
-    if (!clientHandler) {
-      return nextInjectClientProtocols({ nextResult: next(), accepts });
+    if (!handler.isValidPayload(json)) {
+      return nextInjectAcceptedClient({
+        nextResult: next(),
+        clientProtocol,
+      });
     }
-
-    const [clientProtocol, handler] = clientHandler;
 
     const message = await handler.getFrameMessage(json);
 


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Adds type inferencing support to openframes by separating different client protocols into their own middleware.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [ ] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
