### PR TITLE
feat: new slow request api example

### DIFF
--- a/examples/framesjs-starter/app/examples/new-api-slow-request/README.md
+++ b/examples/framesjs-starter/app/examples/new-api-slow-request/README.md
@@ -1,0 +1,6 @@
+# Step 1
+
+Setup a key value store
+https://vercel.com/docs/storage/vercel-kv/quickstart
+
+or follow the steps in this PR to set it up locally using Docker: https://github.com/vercel/storage/issues/281#issuecomment-1650439329

--- a/examples/framesjs-starter/app/examples/new-api-slow-request/frames/route.tsx
+++ b/examples/framesjs-starter/app/examples/new-api-slow-request/frames/route.tsx
@@ -48,7 +48,7 @@ const handleRequest = frames(async (ctx) => {
       case "pending":
         return checkStatusFrame;
       case "success": {
-        if (ctx.currentURL.searchParams.get("reset") === "true") {
+        if (ctx.url.searchParams.get("reset") === "true") {
           // reset to initial state
           await kv.del(uniqueId);
         }
@@ -71,7 +71,7 @@ const handleRequest = frames(async (ctx) => {
         } satisfies types.FrameDefinition<any>;
       }
       case "error": {
-        if (ctx.currentURL.searchParams.get("retry") === "true") {
+        if (ctx.url.searchParams.get("retry") === "true") {
           // reset to initial state
           await kv.del(uniqueId);
 

--- a/examples/framesjs-starter/app/examples/new-api-slow-request/frames/route.tsx
+++ b/examples/framesjs-starter/app/examples/new-api-slow-request/frames/route.tsx
@@ -1,0 +1,126 @@
+import { kv } from "@vercel/kv";
+import { types } from "frames.js/core";
+import { createFrames, Button } from "frames.js/next";
+import { RandomNumberRequestStateValue } from "../slow-fetch/types";
+
+const frames = createFrames({
+  basePath: "/examples/new-api-slow-request/frames",
+});
+
+const handleRequest = frames(async (ctx) => {
+  const initialFrame = {
+    image: (
+      <div tw="w-full h-full bg-slate-700 text-white justify-center items-center">
+        This random number generator takes 10 seconds to respond
+      </div>
+    ),
+    buttons: [
+      <Button action="post" key="1">
+        Generate
+      </Button>,
+    ],
+  } satisfies types.FrameDefinition<any>;
+
+  const checkStatusFrame = {
+    image: (
+      <div tw="w-full h-full bg-slate-700 text-white justify-center items-center">
+        Loading...
+      </div>
+    ),
+    buttons: [
+      <Button action="post" key="1">
+        Check status
+      </Button>,
+    ],
+  } satisfies types.FrameDefinition<any>;
+
+  if (!ctx.message) {
+    return initialFrame;
+  }
+
+  const { requesterFid } = ctx.message;
+  const uniqueId = `fid:${requesterFid}`;
+
+  const existingRequest = await kv.get<RandomNumberRequestStateValue>(uniqueId);
+
+  if (existingRequest) {
+    switch (existingRequest.status) {
+      case "pending":
+        return checkStatusFrame;
+      case "success": {
+        if (ctx.currentURL.searchParams.get("reset") === "true") {
+          // reset to initial state
+          await kv.del(uniqueId);
+        }
+
+        return {
+          image: (
+            <div tw="w-full h-full bg-slate-700 text-white justify-center items-center flex">
+              The number is {existingRequest.data}
+            </div>
+          ),
+          buttons: [
+            <Button
+              action="post"
+              key="1"
+              target={{ pathname: "/", query: { reset: true } }}
+            >
+              Reset
+            </Button>,
+          ],
+        } satisfies types.FrameDefinition<any>;
+      }
+      case "error": {
+        if (ctx.currentURL.searchParams.get("retry") === "true") {
+          // reset to initial state
+          await kv.del(uniqueId);
+
+          return initialFrame;
+        } else {
+          return {
+            image: <span>{existingRequest.error}</span>,
+            buttons: [
+              <Button
+                action="post"
+                key="1"
+                target={{ pathname: "/", query: { retry: true } }}
+              >
+                Retry
+              </Button>,
+            ],
+          } satisfies types.FrameDefinition<any>;
+        }
+      }
+    }
+  } else {
+    await kv.set<RandomNumberRequestStateValue>(
+      uniqueId,
+      {
+        status: "pending",
+        timestamp: new Date().getTime(),
+      },
+      // set as pending for one minute
+      { ex: 60 }
+    );
+
+    // start request, don't await it! Return a loading page, let this run in the background
+    fetch(
+      new URL(
+        "/examples/new-api-slow-request/slow-fetch",
+        process.env.NEXT_PUBLIC_HOST
+      ).toString(),
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(await ctx.request.clone().json()),
+      }
+    );
+  }
+
+  return initialFrame;
+});
+
+export const GET = handleRequest;
+export const POST = handleRequest;

--- a/examples/framesjs-starter/app/examples/new-api-slow-request/page.tsx
+++ b/examples/framesjs-starter/app/examples/new-api-slow-request/page.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import { currentURL } from "../../utils";
+import { createDebugUrl } from "../../debug";
+import type { Metadata } from "next";
+import { fetchMetadata } from "frames.js/next";
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: "New api example",
+    description: "This is a new api example",
+    other: {
+      ...(await fetchMetadata(
+        new URL(
+          "/examples/new-api-slow-request/frames",
+          process.env.VERCEL_URL || "http://localhost:3000"
+        )
+      )),
+    },
+  };
+}
+
+export default async function Home() {
+  const url = currentURL("/examples/new-api-slow-request");
+
+  return (
+    <div>
+      Slow request example
+      <Link href={createDebugUrl(url)} className="underline">
+        Debug
+      </Link>
+    </div>
+  );
+}

--- a/examples/framesjs-starter/app/examples/new-api-slow-request/slow-fetch/route.ts
+++ b/examples/framesjs-starter/app/examples/new-api-slow-request/slow-fetch/route.ts
@@ -1,0 +1,53 @@
+import { getFrameMessage } from "frames.js";
+import { NextRequest, NextResponse } from "next/server";
+import { kv } from "@vercel/kv";
+import { RandomNumberRequestStateValue } from "./types";
+import { DEFAULT_DEBUGGER_HUB_URL } from "../../../debug";
+
+const MAXIMUM_KV_RESULT_LIFETIME_IN_SECONDS = 2 * 60; // 2 minutes
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+
+  // verify independently
+  const frameMessage = await getFrameMessage(body, {
+    hubHttpUrl: DEFAULT_DEBUGGER_HUB_URL,
+  });
+
+  const uniqueId = `fid:${frameMessage.requesterFid}`;
+
+  // Wait 10 seconds
+  await new Promise((resolve) => setTimeout(resolve, 10000));
+
+  try {
+    const randomNumber = Math.random();
+
+    await kv.set<RandomNumberRequestStateValue>(
+      uniqueId,
+      {
+        data: randomNumber,
+        status: "success",
+        timestamp: new Date().getTime(),
+      },
+      { ex: MAXIMUM_KV_RESULT_LIFETIME_IN_SECONDS }
+    );
+
+    return NextResponse.json({
+      data: randomNumber,
+      status: "success",
+      timestamp: new Date().getTime(),
+    });
+  } catch (e) {
+    await kv.set<RandomNumberRequestStateValue>(
+      uniqueId,
+      {
+        error: String(e),
+        status: "error",
+        timestamp: new Date().getTime(),
+      },
+      { ex: MAXIMUM_KV_RESULT_LIFETIME_IN_SECONDS }
+    );
+    // Handle errors
+    return NextResponse.json({ message: e }, { status: 500 });
+  }
+}

--- a/examples/framesjs-starter/app/examples/new-api-slow-request/slow-fetch/types.ts
+++ b/examples/framesjs-starter/app/examples/new-api-slow-request/slow-fetch/types.ts
@@ -1,0 +1,15 @@
+export type RandomNumberRequestStateValue =
+  | {
+      error: string;
+      status: "error";
+      timestamp: number;
+    }
+  | {
+      data: number;
+      status: "success";
+      timestamp: number;
+    }
+  | {
+      status: "pending";
+      timestamp: number;
+    };


### PR DESCRIPTION
## Change Summary

This PR adds slow request example using new api. It depends on #196 since it needs the `target` prop on `Button`