### PR TITLE
chore: use ctx in examples

### DIFF
--- a/examples/framesjs-starter/app/examples/new-api-mint-button/frames/route.tsx
+++ b/examples/framesjs-starter/app/examples/new-api-mint-button/frames/route.tsx
@@ -1,10 +1,7 @@
 /* eslint-disable react/jsx-key */
 import { Button, createFrames } from "frames.js/next";
 import { getTokenUrl } from "frames.js";
-import Link from "next/link";
 import { zora } from "viem/chains";
-import { currentURL } from "../../utils";
-import { createDebugUrl } from "../../debug";
 
 const nfts: {
   src: string;
@@ -36,33 +33,33 @@ const nfts: {
   },
 ];
 
-export const frames = createFrames({
+const frames = createFrames({
   basePath: "/examples/new-api-mint-button/frames",
   initialState: {
     pageIndex: 0,
   },
 });
 
-const handleRequest = frames(async ({ pressedButton, message, state }) => {
+const handleRequest = frames(async (ctx) => {
   return {
-    image: nfts[state.pageIndex]!.src,
+    image: nfts[ctx.state.pageIndex]!.src,
     imageOptions: {
       aspectRatio: "1:1",
     },
     buttons: [
       <Button
         action="post"
-        state={{ pageIndex: (state.pageIndex - 1) % nfts.length }}
+        state={{ pageIndex: (ctx.state.pageIndex - 1) % nfts.length }}
       >
         ←
       </Button>,
       <Button
         action="post"
-        state={{ pageIndex: (state.pageIndex + 1) % nfts.length }}
+        state={{ pageIndex: (ctx.state.pageIndex + 1) % nfts.length }}
       >
         →
       </Button>,
-      <Button action="mint" target={nfts[state.pageIndex]!.tokenUrl}>
+      <Button action="mint" target={nfts[ctx.state.pageIndex]!.tokenUrl}>
         Mint
       </Button>,
     ],

--- a/examples/framesjs-starter/app/examples/new-api-multi-page/frames/route.tsx
+++ b/examples/framesjs-starter/app/examples/new-api-multi-page/frames/route.tsx
@@ -3,14 +3,14 @@ import { createFrames, Button } from "frames.js/next";
 
 const totalPages = 5;
 
-export const frames = createFrames({
+const frames = createFrames({
   basePath: "/examples/new-api/frames",
   initialState: {
     pageIndex: 0,
   },
 });
 
-const handleRequest = frames(async ({ clickedButton, message, state }) => {
+const handleRequest = frames(async (ctx) => {
   const imageUrl = `https://picsum.photos/seed/frames.js-${state.pageIndex}/300/200`;
 
   return {
@@ -18,20 +18,20 @@ const handleRequest = frames(async ({ clickedButton, message, state }) => {
       <div tw="flex flex-col">
         <img width={300} height={200} src={imageUrl} alt="Image" />
         <div tw="flex">
-          This is slide {state?.pageIndex + 1} / {totalPages}
+          This is slide {ctx.state.pageIndex + 1} / {totalPages}
         </div>
       </div>
     ),
     buttons: [
       <Button
         action="post"
-        state={{ pageIndex: (state?.pageIndex - 1) % totalPages }}
+        state={{ pageIndex: (ctx.state.pageIndex - 1) % totalPages }}
       >
         ←
       </Button>,
       <Button
         action="post"
-        state={{ pageIndex: (state?.pageIndex + 1) % totalPages }}
+        state={{ pageIndex: (ctx.state.pageIndex + 1) % totalPages }}
       >
         →
       </Button>,

--- a/examples/framesjs-starter/app/examples/new-api-transaction/frames/route.tsx
+++ b/examples/framesjs-starter/app/examples/new-api-transaction/frames/route.tsx
@@ -6,12 +6,12 @@ const frames = createFrames({
   basePath: "/examples/new-api-transaction",
 });
 
-const handleRequest = frames(async ({ message }) => {
-  if (message?.transactionId) {
+const handleRequest = frames(async (ctx) => {
+  if (ctx.message?.transactionId) {
     return {
       image: (
         <div tw="bg-purple-800 text-white w-full h-full justify-center items-center flex">
-          Transaction submitted! {message.transactionId}
+          Transaction submitted! {ctx.message.transactionId}
         </div>
       ),
       imageOptions: {
@@ -20,7 +20,7 @@ const handleRequest = frames(async ({ message }) => {
       buttons: [
         <Button
           action="link"
-          target={`https://www.onceupon.gg/tx/${message.transactionId}`}
+          target={`https://www.onceupon.gg/tx/${ctx.message.transactionId}`}
         >
           View on block explorer
         </Button>,

--- a/examples/framesjs-starter/app/examples/new-api/frames/frames.ts
+++ b/examples/framesjs-starter/app/examples/new-api/frames/frames.ts
@@ -1,6 +1,5 @@
 import { createFrames } from "frames.js/next";
 
-// @todo here is issue with exporting, ts2742, how to fix it?
 export const frames = createFrames({
   basePath: "/examples/new-api/frames",
 });


### PR DESCRIPTION
## Change Summary

This PR replaces destruture with `ctx` in examples and removes unsupported exports.