### PR TITLE
feat: allow null/undefined/boolean as button

### DIFF
--- a/.changeset/ninety-plums-teach.md
+++ b/.changeset/ninety-plums-teach.md
@@ -1,0 +1,5 @@
+---
+"frames.js": minor
+---
+
+feat: allow null/undefined/boolean as button

--- a/packages/frames.js/src/core/types.ts
+++ b/packages/frames.js/src/core/types.ts
@@ -54,7 +54,8 @@ export type FramesContext<TState extends JsonValue | undefined = JsonValue> = {
 
 type AllowedFramesContextShape = Record<string, any>;
 
-type FrameButtonElement = React.ReactComponentElement<typeof Button>;
+export type FrameButtonElement = React.ReactComponentElement<typeof Button>;
+type AllowedFrameButtonItems = FrameButtonElement | null | undefined | boolean;
 
 /**
  * Frame definition, this is rendered by the frames
@@ -72,14 +73,18 @@ export type FrameDefinition<TState extends JsonValue | undefined> = {
   } & ConstructorParameters<typeof ImageResponse>[1];
   buttons?:
     | []
-    | [FrameButtonElement]
-    | [FrameButtonElement, FrameButtonElement]
-    | [FrameButtonElement, FrameButtonElement, FrameButtonElement]
+    | [AllowedFrameButtonItems]
+    | [AllowedFrameButtonItems, AllowedFrameButtonItems]
     | [
-        FrameButtonElement,
-        FrameButtonElement,
-        FrameButtonElement,
-        FrameButtonElement,
+        AllowedFrameButtonItems,
+        AllowedFrameButtonItems,
+        AllowedFrameButtonItems,
+      ]
+    | [
+        AllowedFrameButtonItems,
+        AllowedFrameButtonItems,
+        AllowedFrameButtonItems,
+        AllowedFrameButtonItems,
       ];
   /**
    * Label for text input, if no value is provided the input is not rendered

--- a/packages/frames.js/src/middleware/renderResponse.tsx
+++ b/packages/frames.js/src/middleware/renderResponse.tsx
@@ -3,6 +3,7 @@ import { ImageResponse } from "@vercel/og";
 import { type Frame, getFrameFlattened, getFrameHtmlHead } from "..";
 import type { ButtonProps } from "../core/components";
 import {
+  FrameButtonElement,
   FrameDefinition,
   FramesHandlerFunctionReturnType,
   FramesMiddleware,
@@ -115,14 +116,18 @@ export function renderResponse(): FramesMiddleware<any, {}> {
                   throw new ImageRenderError("Could not render image");
                 }
               ),
-        buttons: result.buttons?.map(
-          (button, i): NonNullable<Frame["buttons"]>[number] => {
+        buttons: result.buttons
+          ?.slice()
+          .filter(
+            (v: any): v is FrameButtonElement => v && typeof v === "object"
+          )
+          .map((button, i): NonNullable<Frame["buttons"]>[number] => {
             if (!("type" in button && "props" in button)) {
               throw new InvalidButtonShapeError("Invalid button provided");
             }
 
             if (i > 3) {
-              throw new InvalidButtonCountError("Only 4 buttons are allowed");
+              throw new InvalidButtonCountError("Up to 4 buttons are allowed");
             }
 
             const props = button.props as ButtonProps;
@@ -183,8 +188,7 @@ export function renderResponse(): FramesMiddleware<any, {}> {
                   "Unrecognized button action"
                 );
             }
-          }
-        ) as Frame["buttons"],
+          }) as Frame["buttons"],
         inputText: result.textInput,
         imageAspectRatio: result.imageOptions?.aspectRatio ?? "1.91:1",
         accepts: result.accepts,


### PR DESCRIPTION
## Change Summary

This PR adds a possibility to use ternaries in buttons without type hacks by allowing `null/undefined/boolean`.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
