### PR TITLE
fix: jsx lint in docs examples

### DIFF
--- a/docs/pages/guides/create-frame.mdx
+++ b/docs/pages/guides/create-frame.mdx
@@ -23,6 +23,7 @@ This guide shows you how to add frames rendering to your next.js + tailwind app 
 
 ```tsx filename="// ./app/frames/route.tsx"
 // ./app/frames/route.tsx
+/* eslint-disable react/jsx-key */
 import { createFrames, Button } from "frames.js/next";
 
 const frames = createFrames();

--- a/docs/pages/guides/multiple-frames.mdx
+++ b/docs/pages/guides/multiple-frames.mdx
@@ -11,6 +11,7 @@ There's two different ways of navigating between frames.
 The first way is by defining the `state` prop of a `Button`, and using that state to return a different Frame in the handler. See below
 
 ```tsx
+/* eslint-disable react/jsx-key */
 import { createFrames, Button } from "frames.js/next";
 
 const totalPages = 5;

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -70,6 +70,7 @@ export default function Home(props) {
 
 ```ts filename="./app/frames/route.tsx"
 // ./app/frames/route.tsx
+/* eslint-disable react/jsx-key */
 import { createFrames, Button } from 'frames.js/next';
 
 const frames = createFrames();

--- a/docs/pages/reference/core/createFrames.mdx
+++ b/docs/pages/reference/core/createFrames.mdx
@@ -67,6 +67,7 @@ If you wish to have dynamic content in your frame which is re-rendered on every 
 Here is an example of a frame definition with a `Cache-Control` header set to `max-age=0`. It will always show the current time in the user's feed.
 
 ```tsx
+/* eslint-disable react/jsx-key */
 import { Button } from "frames.js/next";
 import { createFrames } from "frames.js/next";
 

--- a/docs/pages/reference/core/express/index.mdx
+++ b/docs/pages/reference/core/express/index.mdx
@@ -5,6 +5,7 @@ Frames.js can be easily integrated to [Express.js](https://expressjs.com) server
 ## Usage
 
 ```tsx
+/* eslint-disable react/jsx-key */
 import express from "express";
 import { createFrames, Button } from "frames/express";
 

--- a/docs/pages/reference/core/hono/index.mdx
+++ b/docs/pages/reference/core/hono/index.mdx
@@ -5,6 +5,7 @@ Frames.js can be easily integrated to [Hono](https://hono.dev) server.
 ## Usage
 
 ```tsx
+/* eslint-disable react/jsx-key */
 import { createFrames, Button } from "frames.js/hono";
 import { Hono } from "hono";
 

--- a/docs/pages/reference/core/next/index.mdx
+++ b/docs/pages/reference/core/next/index.mdx
@@ -10,6 +10,7 @@ Frames handler is responsible for rendering your Frames and also reacts to user 
 
 ```tsx
 // app/frames/routes.tsx
+/* eslint-disable react/jsx-key */
 import { createFrames, Button } from "frames.js/next";
 
 const frames = createFrames();

--- a/docs/pages/reference/core/redirect.mdx
+++ b/docs/pages/reference/core/redirect.mdx
@@ -3,6 +3,7 @@
 `redirect()` must be used only in response to `post_redirect` button clicks. It accepts full URL as an argument.
 
 ```tsx
+/* eslint-disable react/jsx-key */
 import { Button, createFrames, redirect } from "frames.js/core";
 
 const frames = createFrames();

--- a/docs/pages/reference/core/remix/index.mdx
+++ b/docs/pages/reference/core/remix/index.mdx
@@ -10,6 +10,7 @@ Frames handler is responsible for rendering your Frames and also reacts to user 
 
 ```tsx
 // app/routes/frames.tsx
+/* eslint-disable react/jsx-key */
 import { createFrames, Button } from "frames.js/remix";
 
 const frames = createFrames();


### PR DESCRIPTION
## Change Summary

- updates docs with eslint ignoring jsx rules

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
