### PR TITLE
fix: fetchMetadata tests

### DIFF
--- a/.changeset/honest-nails-hunt.md
+++ b/.changeset/honest-nails-hunt.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix: update fetchMetadata tests

--- a/packages/frames.js/src/next/fetchMetadata.test.ts
+++ b/packages/frames.js/src/next/fetchMetadata.test.ts
@@ -29,13 +29,11 @@ describe("fetchMetadata", () => {
     });
   });
 
-  it("throws on invalid response", async () => {
+  it("returns empty object on failed response", async () => {
     nock("http://localhost:3000").get("/frames").reply(404);
 
     await expect(
       fetchMetadata(new URL("/frames", "http://localhost:3000"))
-    ).rejects.toThrow(
-      "Failed to fetch frames metadata from http://localhost:3000/frames. The server returned 404 Not Found response."
-    );
+    ).resolves.toEqual({});
   });
 });


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
`fetchMetadata` now returns an empty object and logs a warning on failed response

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
