### PR TITLE
fix: nextjs fetchMetadata cache issue

### DIFF
--- a/.changeset/spotty-colts-provide.md
+++ b/.changeset/spotty-colts-provide.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix(nextjs): fetchMetadata cache issue

--- a/packages/frames.js/src/next/fetchMetadata.ts
+++ b/packages/frames.js/src/next/fetchMetadata.ts
@@ -35,6 +35,7 @@ export async function fetchMetadata(
         // we use Accept header to get the response in JSON format, this is automatically supported by frames.js renderResponse middleware
         Accept: FRAMES_META_TAGS_HEADER,
       },
+      cache: "no-cache",
     });
 
     if (response?.ok) {


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Fixes initial frame not updating when `fetchMetadata` is used in `generateMetadata` due to caching rules.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
