### PR TITLE
feat: open frames full tags

### DIFF
--- a/.changeset/clean-games-brush.md
+++ b/.changeset/clean-games-brush.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+full sets of open frames tags and fixes getFrame

--- a/packages/frames.js/src/getFrame.test.ts
+++ b/packages/frames.js/src/getFrame.test.ts
@@ -182,28 +182,7 @@ describe("getFrame", () => {
     const exampleFrame: Frame = {
       version: "vNext",
       image: "http://example.com/image.png",
-      buttons: [
-        {
-          label: "1",
-          action: "post",
-          target: undefined,
-        },
-        {
-          label: "2",
-          action: "post_redirect",
-          target: undefined,
-        },
-        {
-          label: "3",
-          action: "link",
-          target: "https://example.com",
-        },
-        {
-          label: "Mint",
-          action: "mint",
-          target: "eip155:7777777:0x060f3edd18c47f59bd23d063bbeb9aa4a8fec6df",
-        },
-      ],
+
       postUrl: "https://example.com",
       accepts: [
         {
@@ -211,6 +190,35 @@ describe("getFrame", () => {
           version: "vNext",
         },
       ],
+      buttons: [
+        {
+          action: "post",
+          label: "1",
+          post_url: undefined,
+          target: undefined,
+        },
+        {
+          action: "post_redirect",
+          label: "2",
+          post_url: undefined,
+          target: undefined,
+        },
+        {
+          action: "link",
+          label: "3",
+          post_url: undefined,
+          target: "https://example.com",
+        },
+        {
+          action: "mint",
+          label: "Mint",
+          post_url: undefined,
+          target: "eip155:7777777:0x060f3edd18c47f59bd23d063bbeb9aa4a8fec6df",
+        },
+      ],
+      imageAspectRatio: undefined,
+      inputText: undefined,
+      state: undefined,
     };
 
     const html = getFrameHtml(exampleFrame);

--- a/packages/frames.js/src/getFrame.ts
+++ b/packages/frames.js/src/getFrame.ts
@@ -100,6 +100,8 @@ export function getFrame({
       .map((i, elem) => parseButtonElement(elem))
       .filter((i, elem) => elem !== null)
       .toArray()
+      // only take the first, to deduplicate of and fc:frame
+      .slice(0, 1)
   );
   const buttonActions = [1, 2, 3, 4].flatMap((el) =>
     $(
@@ -108,6 +110,8 @@ export function getFrame({
       .map((i, elem) => parseButtonElement(elem))
       .filter((i, elem) => elem !== null)
       .toArray()
+      // only take the first, to deduplicate of and fc:frame
+      .slice(0, 1)
   );
 
   const buttonTargets = [1, 2, 3, 4].flatMap((el) =>
@@ -117,6 +121,8 @@ export function getFrame({
       .map((i, elem) => parseButtonElement(elem))
       .filter((i, elem) => elem !== null)
       .toArray()
+      // only take the first, to deduplicate of and fc:frame
+      .slice(0, 1)
   );
 
   const buttonPostUrls = [1, 2, 3, 4].flatMap((el) =>
@@ -126,6 +132,8 @@ export function getFrame({
       .map((i, elem) => parseButtonElement(elem))
       .filter((i, elem) => elem !== null)
       .toArray()
+      // only take the first, to deduplicate of and fc:frame
+      .slice(0, 1)
   );
 
   let buttonsValidation = [false, false, false, false];

--- a/packages/frames.js/src/getFrameFlattened.test.ts
+++ b/packages/frames.js/src/getFrameFlattened.test.ts
@@ -52,6 +52,20 @@ describe("getFrameFlattened", () => {
       "fc:frame:state": JSON.stringify({ foo: "bar" }),
       "of:accepts:xmtp": "vNext",
       "of:accepts:farcaster": "vNext",
+      "of:button:1": "Button 1",
+      "of:button:1:action": "post",
+      "of:button:1:post_url": undefined,
+      "of:button:1:target": "target1",
+      "of:button:2": "Button 2",
+      "of:button:2:action": "post",
+      "of:button:2:post_url": undefined,
+      "of:button:2:target": "target2",
+      "of:image": "https://example.com/image.png",
+      "of:image:aspect_ratio": "1:1",
+      "of:input:text": "input",
+      "of:post_url": "https://example.com/post",
+      "of:state": '{"foo":"bar"}',
+      "of:version": "vNext",
     });
   });
 });

--- a/packages/frames.js/src/getFrameFlattened.ts
+++ b/packages/frames.js/src/getFrameFlattened.ts
@@ -6,11 +6,43 @@ import type { Frame, FrameFlattened } from "./types";
  * @returns a plain object with frame metadata keys and values according to the frame spec, using their lengthened syntax, e.g. "fc:frame:image"
  */
 export function getFrameFlattened(frame: Frame): FrameFlattened {
+  const openFrames = !!frame.accepts?.length
+    ? {
+        // custom of tags
+        [`of:version`]: frame.version,
+        ...frame.accepts?.reduce(
+          (acc: Record<string, string>, { id, version }) => {
+            acc[`of:accepts:${id}`] = version;
+            return acc;
+          },
+          {}
+        ),
+        // same as fc:frame tags
+        [`of:image`]: frame.image,
+        [`of:post_url`]: frame.postUrl,
+        [`of:input:text`]: frame.inputText,
+        ...(frame.state ? { [`of:state`]: frame.state } : {}),
+        ...(frame.imageAspectRatio
+          ? { [`of:image:aspect_ratio`]: frame.imageAspectRatio }
+          : {}),
+        ...frame.buttons?.reduce(
+          (acc, button, index) => ({
+            ...acc,
+            [`of:button:${index + 1}`]: button.label,
+            [`of:button:${index + 1}:action`]: button.action,
+            [`of:button:${index + 1}:target`]: button.target,
+            [`of:button:${index + 1}:post_url`]: button.post_url,
+          }),
+          {}
+        ),
+      }
+    : {};
+
   const metadata: FrameFlattened = {
-    "fc:frame": frame.version,
-    "fc:frame:image": frame.image,
-    "fc:frame:post_url": frame.postUrl,
-    "fc:frame:input:text": frame.inputText,
+    [`fc:frame`]: frame.version,
+    [`fc:frame:image`]: frame.image,
+    [`fc:frame:post_url`]: frame.postUrl,
+    [`fc:frame:input:text`]: frame.inputText,
     ...(frame.state ? { [`fc:frame:state`]: frame.state } : {}),
     ...(frame.imageAspectRatio
       ? { [`fc:frame:image:aspect_ratio`]: frame.imageAspectRatio }
@@ -25,10 +57,7 @@ export function getFrameFlattened(frame: Frame): FrameFlattened {
       }),
       {}
     ),
-    ...frame.accepts?.reduce((acc: Record<string, string>, { id, version }) => {
-      acc[`of:accepts:${id}`] = version;
-      return acc;
-    }, {}),
+    ...openFrames,
   };
 
   return metadata;

--- a/packages/frames.js/src/getFrameHtml.ts
+++ b/packages/frames.js/src/getFrameHtml.ts
@@ -64,11 +64,40 @@ export function getFrameHtmlHead(frame: Frame): string {
         ? `<meta name="fc:frame:button:${index + 1}:post_url" content="${button.post_url}"/>`
         : "",
     ]) ?? []),
-    ...(frame.accepts?.map(
-      ({ id, version }) =>
-        `<meta name="of:accepts:${id}" content="${version}"/>`
-    ) ?? []),
   ];
+
+  if (frame.accepts?.length) {
+    tags.push(
+      ...[
+        `<meta name="of:version" content="${frame.version}"/>`,
+        `<meta name="of:image" content="${frame.image}"/>`,
+        `<meta name="of:post_url" content="${frame.postUrl}"/>`,
+        frame.state ? `<meta name="of:state" content='${frame.state}'/>` : "",
+        frame.imageAspectRatio
+          ? `<meta name="of:image:aspect_ratio" content="${frame.imageAspectRatio}"/>`
+          : "",
+        frame.inputText
+          ? `<meta name="of:input:text" content="${frame.inputText}"/>`
+          : "",
+        ...(frame.buttons?.flatMap((button, index) => [
+          `<meta name="of:button:${index + 1}" content="${button.label}"/>`,
+          button.action
+            ? `<meta name="of:button:${index + 1}:action" content="${button.action}"/>`
+            : "",
+          button.target
+            ? `<meta name="of:button:${index + 1}:target" content="${button.target}"/>`
+            : "",
+          button.post_url
+            ? `<meta name="of:button:${index + 1}:post_url" content="${button.post_url}"/>`
+            : "",
+        ]) ?? []),
+      ],
+      ...(frame.accepts?.map(
+        ({ id, version }) =>
+          `<meta name="of:accepts:${id}" content="${version}"/>`
+      ) ?? [])
+    );
+  }
 
   return tags.join("");
 }

--- a/packages/frames.js/src/types.ts
+++ b/packages/frames.js/src/types.ts
@@ -34,7 +34,7 @@ type FrameOptionalStringKeys =
   | "fc:frame:image:aspect_ratio"
   | "fc:frame:input:text"
   | "fc:frame:state"
-  | `of:accepts:${string}`;
+  | keyof OpenFramesProperties;
 type FrameOptionalActionButtonTypeKeys =
   `fc:frame:button:${1 | 2 | 3 | 4}:action`;
 type FrameOptionalButtonStringKeys =
@@ -57,6 +57,25 @@ type FrameRequiredProperties = {
   "fc:frame": FrameVersion;
   "fc:frame:image": string;
   "fc:frame:post_url": string;
+};
+
+export type OpenFramesProperties = {
+  "of:version": FrameVersion;
+  "of:image": string;
+  "of:post_url": string;
+  "of:image:aspect_ratio": string;
+  "of:input:text": string;
+  "of:state": string;
+} & {
+  [s in `of:accepts:${string}`]: string;
+} & {
+  [s in `of:button:${1 | 2 | 3 | 4}`]: string;
+} & {
+  [s in `of:button:${1 | 2 | 3 | 4}:action`]: string;
+} & {
+  [s in `of:button:${1 | 2 | 3 | 4}:target`]: string;
+} & {
+  [s in `of:button:${1 | 2 | 3 | 4}:post_url`]: string;
 };
 
 /** A Frame represented as an object with keys and values corresponding to the Frames spec: https://docs.farcaster.xyz/reference/frames/spec */


### PR DESCRIPTION
## Change Summary

- prints the full set of `of` tags when an `accepts` value is set
- fixes `getFrame` to handle deduplication correctly

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
