### PR TITLE
docs: basePath is required for searchParams to be populated

### DIFF
--- a/docs/pages/guides/create-frame.mdx
+++ b/docs/pages/guides/create-frame.mdx
@@ -26,7 +26,9 @@ This guide shows you how to add frames rendering to your next.js + tailwind app 
 /* eslint-disable react/jsx-key */
 import { createFrames, Button } from "frames.js/next";
 
-const frames = createFrames();
+const frames = createFrames({
+  basePath: "/frames",
+});
 const handleRequest = frames(async (ctx) => {
   return {
     image: (


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->

- Without providing a `basePath`, the example code does not work and `ctx.searchParams` is an empty object:

![CleanShot 2024-03-23 at 15 09 14@2x](https://github.com/framesjs/frames.js/assets/8302959/b2c75d3c-5ebb-4c38-a970-9df3c6002b9d)

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [ ] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
