### PR TITLE
fix: tx button post_url UrlObject type

### DIFF
--- a/.changeset/three-pumas-walk.md
+++ b/.changeset/three-pumas-walk.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix: add UrlObject type to post_url prop on tx button

--- a/packages/frames.js/src/core/components.ts
+++ b/packages/frames.js/src/core/components.ts
@@ -53,7 +53,7 @@ type TxButtonProps = {
    * URL where a frame message containing the transaction ID will be posted if the transaction succeeds.
    * Overrides the top level frame post_url.
    */
-  post_url?: string;
+  post_url?: string | UrlObject;
 };
 
 export type ButtonProps =


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Adds missing `UrlObject` type to `post_url` of `TxButtonProps`

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
