### PR TITLE
fix(nextjs): getCurrentUrl respect env variables

### DIFF
--- a/.changeset/lucky-bugs-behave.md
+++ b/.changeset/lucky-bugs-behave.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix(nextjs): getCurrentUrl respect VERCEL_URL and APP_URL env variables

--- a/packages/frames.js/src/next/getCurrentUrl.ts
+++ b/packages/frames.js/src/next/getCurrentUrl.ts
@@ -5,18 +5,33 @@ import type { NextRequest } from "next/server.js";
 export function getCurrentUrl(
   req: Request | NextRequest | NextApiRequest | IncomingMessage
 ): URL | undefined {
-  const scheme =
-    process.env.VERCEL_ENV === "production" ? "https://" : "http://";
-  const vercelUrl = process.env.VERCEL_URL;
-  const host = vercelUrl || (req?.headers as any)?.host;
+  const scheme = process.env.NODE_ENV === "production" ? "https://" : "http://";
+  const appUrl = process.env.VERCEL_URL || process.env.APP_URL;
+  const host: string | undefined = (req.headers as any)?.host;
 
-  const relativeUrl = req.url;
-
-  return relativeUrl
-    ? new URL(
-        isValidUrl(relativeUrl) ? relativeUrl : scheme + host + relativeUrl
-      )
+  // Construct a valid URL from the Vercel URL environment variable if it exists
+  const parsedAppUrl = appUrl
+    ? appUrl.startsWith("http://") || appUrl.startsWith("https://")
+      ? appUrl
+      : scheme + appUrl
     : undefined;
+
+  // App URL
+  if (parsedAppUrl && isValidUrl(parsedAppUrl)) {
+    return new URL(parsedAppUrl);
+  }
+
+  // Request URL
+  if (req.url && isValidUrl(req.url)) {
+    return new URL(req.url);
+  }
+
+  // Relative URLs
+  if (host && req.url?.startsWith("/")) {
+    return new URL(`${scheme}${host}${req.url}`);
+  }
+
+  return undefined;
 }
 
 function isValidUrl(url: string) {


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Updates the implementation of `getCurrentUrl` used by the Next.js createFrames adapter to derive the current URL in the following order:
1. `VERCEL_URL` or `APP_URL` if available and prepend `http://` or `https://` depending on `NODE_ENV` if not present
2. `req.url` if valid
3. If `req.url` is a relative URL (starts with `/`), append that to a `host` header if present
4. Otherwise return `undefined`

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
