### PR TITLE
fix: allow node10 resolution to find types in barrel files

### DIFF
--- a/.changeset/modern-coats-complain.md
+++ b/.changeset/modern-coats-complain.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix: correctly import barrel files in node10 resolution

--- a/packages/frames.js/package.json
+++ b/packages/frames.js/package.json
@@ -7,13 +7,14 @@
   "typesVersions": {
     "*": {
       "*": [
-        "./dist/*"
+        "dist/*",
+        "dist/*/index.d.ts"
       ]
     }
   },
   "scripts": {
     "lint": "eslint \"./src/**/*.{ts,tsx}\"",
-    "build": "NODE_OPTIONS='--max-old-space-size=16384' tsup `find ./src -type f \\( -regex '.*\\.tsx*' -a -not -regex '.*\\.test\\.tsx*' \\)` --format cjs,esm --dts",
+    "build": "NODE_OPTIONS='--max-old-space-size=16384' rimraf ./dist && tsup `find ./src -type f \\( -regex '.*\\.tsx*' -a -not -regex '.*\\.test\\.tsx*' \\)` --format cjs,esm --dts",
     "dev": "npm run build -- --watch",
     "test:watch": "jest --watch"
   },


### PR DESCRIPTION
## Change Summary

This PR fixes a resolution issue when using `node10` typescript resolution and the imported path points to barrel file (`index.ts`). 

Following import

```ts
import { createFrames } from 'frames.js/hono';
```

Has been resolved to `frames.js/hono.d.ts` which doesn't exist. 

After the fix it first tries `frames.js/hono.d.ts` and if not found then it tries `frames.js/hono/index.d.ts`.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
