### PR TITLE
fix: debugger history styling

### DIFF
--- a/.changeset/fifty-rice-speak.md
+++ b/.changeset/fifty-rice-speak.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/debugger": patch
+---
+
+fix: debugger history styling improvements

--- a/packages/debugger/app/components/frame-debugger.tsx
+++ b/packages/debugger/app/components/frame-debugger.tsx
@@ -276,12 +276,13 @@ export function FrameDebugger({
                     } as FrameRequest);
                   }}
                 >
-                  <span className="flex flex-row w-full">
+                  <span className="flex text-left flex-row w-full">
                     <span className="border text-gray-500 text-xs font-medium me-2 px-2.5 py-0.5 rounded dark:bg-gray-700 dark:text-gray-300">
                       {frameStackItem.method}
                     </span>
                     <span className="border text-gray-500 text-xs font-medium me-2 px-2.5 py-0.5 rounded dark:bg-gray-700 dark:text-gray-300">
-                      {new URL(frameStackItem.url).protocol}//
+                      {new URL(frameStackItem.url).protocol}
+                      {"//"}
                       {new URL(frameStackItem.url).hostname}
                       {new URL(frameStackItem.url).port
                         ? `:${new URL(frameStackItem.url).port}`
@@ -302,20 +303,27 @@ export function FrameDebugger({
                     </span>
                   </span>
                   <span className="flex flex-row w-full">
-                    <span>{new URL(frameStackItem.url).pathname}</span>
+                    <span className="text-left line-clamp-2 text-ellipsis overflow-hidden break-words">
+                      {new URL(frameStackItem.url).pathname}
+                    </span>
+                    <span className="ml-auto" suppressHydrationWarning>
+                      {frameStackItem.timestamp.toLocaleTimeString()}
+                    </span>
+                  </span>
+                  <div>
                     {Array.from(
                       new URL(frameStackItem.url).searchParams.entries()
                     ).length ? (
                       <HoverCard>
                         <HoverCardTrigger>
-                          <span className="border ml-2 text-gray-500 text-xs font-medium me-2 p-1 cursor-pointer rounded dark:bg-gray-700 dark:text-gray-300">
+                          <span className="border text-gray-500 text-xs font-medium me-2 p-1 cursor-pointer rounded dark:bg-gray-700 dark:text-gray-300">
                             ?params
                           </span>
                         </HoverCardTrigger>
                         <HoverCardContent>
                           <pre
                             id="json"
-                            className="font-mono text-xs"
+                            className="font-mono text-xs text-left"
                             style={{
                               padding: "10px",
                               borderRadius: "4px",
@@ -334,10 +342,7 @@ export function FrameDebugger({
                         </HoverCardContent>
                       </HoverCard>
                     ) : null}
-                    <span className="ml-auto" suppressHydrationWarning>
-                      {frameStackItem.timestamp.toLocaleTimeString()}
-                    </span>
-                  </span>
+                  </div>
                 </button>
               );
             })}


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Cleans up styling for debugger frame history stack

<img width="323" alt="image" src="https://github.com/framesjs/frames.js/assets/5469870/f1d7028f-ddc8-480d-888d-354a9fd13355">


## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
