### PR TITLE
fix: debugger image url length validation

### DIFF
--- a/.changeset/long-bees-obey.md
+++ b/.changeset/long-bees-obey.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix: getFrame validate image url length even if not data url

--- a/packages/frames.js/src/getFrame.ts
+++ b/packages/frames.js/src/getFrame.ts
@@ -295,14 +295,14 @@ export function getFrame({
         });
       }
     }
+  }
 
-    // validate data url is less than 256kb (warpcast)
-    if (getByteLength(image) > 256 * 1024) {
-      addError({
-        message: `Data URI is more than 256kb (${Math.ceil(getByteLength(image) / 1024)}kb)`,
-        key: "fc:frame:image",
-      });
-    }
+  if (image && getByteLength(image) > 256 * 1024) {
+    // validate image url is less than 256kb (warpcast)
+    addError({
+      message: `Image URL is more than 256kb (${Math.ceil(getByteLength(image) / 1024)}kb)`,
+      key: "fc:frame:image",
+    });
   }
 
   if (state && Buffer.from(state).length > 4096) {


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Always validate image URL length in `getFrame`, not only when it's a data URL

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
