### PR TITLE
fix: @frames/render turbo build

### DIFF
--- a/.changeset/five-mangos-try.md
+++ b/.changeset/five-mangos-try.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix: turbo build

--- a/packages/frames.js/package.json
+++ b/packages/frames.js/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "lint": "eslint \"./src/**/*.{ts,tsx}\"",
-    "build": "NODE_OPTIONS='--max-old-space-size=16384' rimraf ./dist && tsup `find ./src -type f \\( -regex '.*\\.tsx*' -a -not -regex '.*\\.test\\.tsx*' \\)` --format cjs,esm --dts",
+    "build": "NODE_OPTIONS='--max-old-space-size=16384' tsup `find ./src -type f \\( -regex '.*\\.tsx*' -a -not -regex '.*\\.test\\.tsx*' \\)` --format cjs,esm --dts",
     "dev": "npm run build -- --watch",
     "test:watch": "jest --watch",
     "update:proto": "curl https://raw.githubusercontent.com/farcasterxyz/hub-monorepo/main/packages/core/src/protobufs/generated/message.ts -o src/farcaster/generated/message.ts"


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Removes the `rimraf` command in the frames.js build step which breaks parallel builds

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
