### PR TITLE
fix: getCurrentUrl env priorities

### DIFF
--- a/.changeset/new-moose-talk.md
+++ b/.changeset/new-moose-talk.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix(nextjs): prioritize APP_URL over VERCEL_URL

--- a/packages/frames.js/src/next/getCurrentUrl.ts
+++ b/packages/frames.js/src/next/getCurrentUrl.ts
@@ -6,7 +6,7 @@ export function getCurrentUrl(
   req: Request | NextRequest | NextApiRequest | IncomingMessage
 ): URL | undefined {
   const scheme = process.env.NODE_ENV === "production" ? "https://" : "http://";
-  const appUrl = process.env.VERCEL_URL || process.env.APP_URL;
+  const appUrl = process.env.APP_URL || process.env.VERCEL_URL;
   const host: string | undefined = (req.headers as any)?.host;
 
   const pathname = req.url?.startsWith("/")


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Allow the user to override VERCEL_URL with APP_URL in the next.js package's `getCurrentUrl` function

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
