### PR TITLE
fix: allow to explicitly set state using generics

### DIFF
--- a/.changeset/eight-hounds-remember.md
+++ b/.changeset/eight-hounds-remember.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix: allow to explicitly set state using generics

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -69,8 +69,11 @@ jobs:
       - name: Install dependencies
         run: yarn --frozen-lockfile
 
-      - name: Typecheck
+      - name: Build
         run: yarn build:ci
+
+      - name: Typecheck
+        run: yarn typecheck
 
   test:
     needs: [lint, typecheck]

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "turbo lint --filter=!template-*",
     "test:ci": "jest --ci",
     "test": "cd ./packages/frames.js && npm run test:watch",
+    "typecheck": "turbo typecheck",
     "publish-packages": "yarn build lint && changeset version && changeset publish && git push --follow-tags origin main",
     "publish-canary": "turbo run build lint && cd ./packages/frames.js && yarn publish --tag canary && git push --follow-tags origin main",
     "format": "prettier --write \"**/*.{ts,tsx,md}\""

--- a/packages/frames.js/package.json
+++ b/packages/frames.js/package.json
@@ -17,7 +17,8 @@
     "build": "NODE_OPTIONS='--max-old-space-size=16384' tsup",
     "dev": "npm run build -- --watch",
     "test:watch": "jest --watch",
-    "update:proto": "curl https://raw.githubusercontent.com/farcasterxyz/hub-monorepo/main/packages/core/src/protobufs/generated/message.ts -o src/farcaster/generated/message.ts"
+    "update:proto": "curl https://raw.githubusercontent.com/farcasterxyz/hub-monorepo/main/packages/core/src/protobufs/generated/message.ts -o src/farcaster/generated/message.ts",
+    "typecheck": "tsc --noEmit"
   },
   "repository": {
     "type": "git",
@@ -257,6 +258,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@cloudflare/workers-types": "^4.20240320.1",
+    "@types/express": "^4.17.21",
     "@xmtp/frames-validator": "^0.5.2",
     "next": "^14.1.0",
     "react": "^18.2.0",

--- a/packages/frames.js/src/cloudflare-workers/index.test.tsx
+++ b/packages/frames.js/src/cloudflare-workers/index.test.tsx
@@ -24,4 +24,32 @@ describe("cloudflare workers adapter", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toBe("text/html");
   });
+
+  it('works properly with state', async () => {
+    type State = {
+      test: boolean;
+    };
+    const frames = lib.createFrames<State>({
+      initialState: {
+        test: false,
+      },
+    });
+
+    const handler = frames(async (ctx) => {
+      expect(ctx.state).toEqual({ test: false });
+
+      return {
+        image: 'http://test.png',
+        state: ctx.state satisfies State,
+      };
+    });
+
+    const request = new Request("http://localhost:3000");
+
+    // @ts-expect-error - expects fetcher property on request but it is not used by our lib
+    const response = await handler(request, {}, {});
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/html");
+  });
 });

--- a/packages/frames.js/src/cloudflare-workers/index.ts
+++ b/packages/frames.js/src/cloudflare-workers/index.ts
@@ -43,14 +43,16 @@ type DefaultMiddleware<TEnv> = [
  * });
  *
  * @example
- * // With custom type for Env
- * import { createFrames, Button } from 'frames.js/cloudflare-workers';
+ * // With custom type for Env and state
+ * import { createFrames, Button, type types } from 'frames.js/cloudflare-workers';
  *
  * type Env = {
- * secret: string;
+ *   secret: string;
  * };
  *
- * const frames = createFrames<Env>();
+ * type State = { test: boolean };
+ *
+ * const frames = createFrames<State, Env>();
  * const fetch = frames(async (ctx) => {
  *  return {
  *    image: <span>{ctx.cf.env.secret}</span>,
@@ -67,11 +69,11 @@ type DefaultMiddleware<TEnv> = [
  * } satisfies ExportedHandler;
  */
 export function createFrames<
+  TState extends JsonValue | undefined = JsonValue | undefined,
   TEnv = unknown,
   TFramesMiddleware extends
     | FramesMiddleware<any, any>[]
     | undefined = undefined,
-  TState extends JsonValue = JsonValue,
 >(
   options?: types.FramesOptions<TState, TFramesMiddleware>
 ): FramesRequestHandlerFunction<

--- a/packages/frames.js/src/cloudflare-workers/test.types.tsx
+++ b/packages/frames.js/src/cloudflare-workers/test.types.tsx
@@ -1,0 +1,46 @@
+import { ExecutionContext, Request as CfRequest, ExportedHandlerFetchHandler } from '@cloudflare/workers-types';
+import { createFrames, types } from '.';
+
+const framesWithoutState = createFrames();
+framesWithoutState(async (ctx) => {
+  ctx.initialState satisfies types.JsonValue | undefined;
+  ctx.state satisfies types.JsonValue | undefined; 
+
+  return {
+    image: 'http://test.png',
+  };
+}) satisfies ExportedHandlerFetchHandler;
+
+const framesWithInferredState = createFrames({
+  initialState: { test: true },
+});
+
+framesWithInferredState(async (ctx) => {
+  ctx.state satisfies { test: boolean; };
+
+  return {
+    image: 'http://test.png',
+  };
+}) satisfies ExportedHandlerFetchHandler;
+
+const framesWithExplicitState = createFrames<{ test: boolean }>({});
+framesWithExplicitState(async (ctx) => {
+  ctx.state satisfies { test: boolean };
+  ctx satisfies { initialState?: {test: boolean}; message?: any, pressedButton?: any };
+  ctx satisfies { cf: { env: unknown; ctx: ExecutionContext; req: CfRequest }}
+
+  return {
+    image: 'http://test.png',
+  };
+}) satisfies ExportedHandlerFetchHandler;
+
+const framesWithExplicitStateAndEnv = createFrames<{ test: boolean }, { secret: string }>({});
+framesWithExplicitStateAndEnv(async (ctx) => {
+  ctx.state satisfies { test: boolean };
+  ctx satisfies { initialState?: { test: boolean }; message?: any, pressedButton?: any; request: Request; };
+  ctx satisfies { cf: { env: { secret: string }; ctx: ExecutionContext; req: CfRequest }}
+
+  return {
+    image: 'http://test.png',
+  };
+}) satisfies ExportedHandlerFetchHandler<{ secret: string }>;

--- a/packages/frames.js/src/core/createFrames.ts
+++ b/packages/frames.js/src/core/createFrames.ts
@@ -11,7 +11,7 @@ import type {
 } from "./types";
 
 export function createFrames<
-  TState extends JsonValue | undefined,
+  TState extends JsonValue | undefined = JsonValue | undefined,
   TMiddlewares extends FramesMiddleware<any, any>[] | undefined = undefined,
 >({
   basePath = "/",

--- a/packages/frames.js/src/core/test.types.tsx
+++ b/packages/frames.js/src/core/test.types.tsx
@@ -1,0 +1,46 @@
+import { createFrames, types } from '.';
+
+type Handler = (req: Request) => Promise<Response>;
+
+const framesWithoutState = createFrames();
+framesWithoutState(async (ctx) => {
+  ctx.initialState satisfies types.JsonValue | undefined;
+  ctx.state satisfies types.JsonValue | undefined;
+
+  return {
+    image: 'http://test.png',
+  };
+}) satisfies Handler;
+
+const framesWithInferredState = createFrames({
+  initialState: { test: true },
+});
+
+framesWithInferredState(async (ctx) => {
+  ctx.state satisfies { test: boolean };
+
+  return {
+    image: 'http://test.png',
+  };
+}) satisfies Handler;
+
+const framesWithExplicitState = createFrames<{ test: boolean }>({});
+framesWithExplicitState(async (ctx) => {
+  ctx.state satisfies { test: boolean };
+  ctx satisfies { initialState?: {test: boolean}; message?: any, pressedButton?: any };
+
+  return {
+    image: 'http://test.png',
+  };
+}) satisfies Handler;
+
+const framesWithExplicitStateAndEnv = createFrames<{ test: boolean }>({});
+framesWithExplicitStateAndEnv(async (ctx) => {
+  ctx.state satisfies { test: boolean };
+  ctx satisfies { initialState?: { test: boolean }; message?: any, pressedButton?: any; request: Request; };
+
+
+  return {
+    image: 'http://test.png',
+  };
+}) satisfies Handler;

--- a/packages/frames.js/src/core/types.ts
+++ b/packages/frames.js/src/core/types.ts
@@ -212,8 +212,8 @@ export type CreateFramesFunctionDefinition<
     | undefined,
   TRequestHandlerFunction extends Function,
 > = <
+  TState extends JsonValue | undefined = JsonValue | undefined,
   TFrameMiddleware extends FramesMiddleware<any, any>[] | undefined = undefined,
-  TState extends JsonValue = JsonValue,
 >(
   options?: FramesOptions<TState, TFrameMiddleware>
 ) => FramesRequestHandlerFunction<

--- a/packages/frames.js/src/express/index.test.tsx
+++ b/packages/frames.js/src/express/index.test.tsx
@@ -101,4 +101,32 @@ describe("express adapter", () => {
         );
       });
   });
+
+  it('works properly with state', async () => {
+    type State = {
+      test: boolean;
+    };
+    const app = express();
+    const frames = lib.createFrames<State>({
+      initialState: {
+        test: false,
+      },
+    });
+
+    const expressHandler = frames(async (ctx) => {
+      expect(ctx.state).toEqual({ test: false });
+
+      return {
+        image: 'http://test.png',
+        state: ctx.state satisfies State,
+      };
+    });
+
+    app.use("/", expressHandler);
+
+    await request(app)
+      .get("/")
+      .expect("Content-Type", "text/html")
+      .expect(200);
+  });
 });

--- a/packages/frames.js/src/express/test.types.tsx
+++ b/packages/frames.js/src/express/test.types.tsx
@@ -1,0 +1,49 @@
+import { Handler } from 'express';
+import { createFrames, types } from '.';
+
+const framesWithoutState = createFrames();
+framesWithoutState(async ctx => {
+  ctx.initialState satisfies types.JsonValue | undefined;
+  ctx.state satisfies types.JsonValue | undefined;
+
+  return {
+    image: 'http://test.png'
+  };
+}) satisfies Handler;
+
+const framesWithInferredState = createFrames({
+  initialState: {
+    test: true
+  }
+});
+framesWithInferredState(async ctx => {
+  ctx.initialState satisfies { test: boolean; };
+  ctx.state satisfies {
+    test: boolean;
+  };
+
+  return {
+    image: 'http://test.png'
+  };
+}) satisfies Handler;
+
+const framesWithExplicitState = createFrames<{
+  test: boolean;
+}>({});
+framesWithExplicitState(async ctx => {
+  ctx.state satisfies {
+    test: boolean;
+  };
+  ctx.initialState satisfies {
+    test: boolean;
+  };
+  ctx satisfies {
+    message?: any;
+    pressedButton?: any;
+    request: Request;
+  }
+
+  return {
+    image: 'http://test.png'
+  };
+}) satisfies Handler;

--- a/packages/frames.js/src/hono/index.test.tsx
+++ b/packages/frames.js/src/hono/index.test.tsx
@@ -28,4 +28,35 @@ describe("hono adapter", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toBe("text/html");
   });
+
+  it('works properly with state', async () => {
+    type State = {
+      test: boolean;
+    };
+    const frames = lib.createFrames<State>({
+      initialState: {
+        test: false,
+      },
+    });
+
+    const handler = frames(async (ctx) => {
+      expect(ctx.state).toEqual({ test: false });
+
+      return {
+        image: 'http://test.png',
+        state: ctx.state satisfies State,
+      };
+    });
+
+    const app = new Hono();
+
+    app.on(["GET", "POST"], "/", handler);
+
+    const request = new Request("http://localhost:3000");
+
+    const response = await app.request(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/html");
+  });
 });

--- a/packages/frames.js/src/hono/test.types.tsx
+++ b/packages/frames.js/src/hono/test.types.tsx
@@ -1,0 +1,49 @@
+import { Handler } from 'hono';
+import { createFrames, types } from '.';
+
+const framesWithoutState = createFrames();
+framesWithoutState(async ctx => {
+  ctx.initialState satisfies types.JsonValue | undefined;
+  ctx.state satisfies types.JsonValue | undefined;
+
+  return {
+    image: 'http://test.png'
+  };
+}) satisfies Handler;
+
+const framesWithInferredState = createFrames({
+  initialState: {
+    test: true
+  }
+});
+framesWithInferredState(async ctx => {
+  ctx.state satisfies {
+    test: boolean;
+  };
+  ctx.initialState satisfies { test: boolean; };
+
+  return {
+    image: 'http://test.png'
+  };
+}) satisfies Handler;
+
+const framesWithExplicitState = createFrames<{
+  test: boolean;
+}>({});
+framesWithExplicitState(async ctx => {
+  ctx.state satisfies {
+    test: boolean;
+  };
+  ctx.initialState satisfies {
+    test: boolean;
+  };
+  ctx satisfies {
+    message?: any;
+    pressedButton?: any;
+    request: Request;
+  }
+
+  return {
+    image: 'http://test.png'
+  };
+}) satisfies Handler;

--- a/packages/frames.js/src/next/index.test.ts
+++ b/packages/frames.js/src/next/index.test.ts
@@ -1,4 +1,5 @@
 import * as lib from ".";
+import { NextRequest } from "next/server";
 
 describe("next adapter", () => {
   it.each(["Button", "createFrames", "fetchMetadata"])(
@@ -7,4 +8,29 @@ describe("next adapter", () => {
       expect(lib).toHaveProperty(exportName);
     }
   );
+
+  it("correctly integrates with next.js", async () => {
+    type State = {
+      test: boolean;
+    };
+    const frames = lib.createFrames<State>({
+      initialState: {
+        test: false,
+      },
+    });
+
+    const handleRequest = frames(async (ctx) => {
+      expect(ctx.state).toEqual({ test: false });
+
+      return {
+        image: "http://test.png",
+        // satisfies is here so if also check if type is correct
+        state: ctx.state satisfies State,
+      };
+    });
+
+    await expect(
+      handleRequest(new NextRequest("http://localhost:3000"))
+    ).resolves.toHaveProperty("status", 200);
+  });
 });

--- a/packages/frames.js/src/next/test.types.tsx
+++ b/packages/frames.js/src/next/test.types.tsx
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createFrames, types } from '.';
+
+type Handler = (req: NextRequest) => Promise<NextResponse>;
+
+const framesWithoutState = createFrames();
+framesWithoutState(async ctx => {
+  ctx.initialState satisfies types.JsonValue | undefined;
+  ctx.state satisfies types.JsonValue | undefined;
+
+  return {
+    image: 'http://test.png'
+  };
+}) satisfies Handler;
+
+const framesWithInferredState = createFrames({
+  initialState: {
+    test: true
+  }
+});
+framesWithInferredState(async ctx => {
+  ctx.initialState satisfies { test: boolean; };
+  ctx.state satisfies {
+    test: boolean;
+  };
+
+  return {
+    image: 'http://test.png'
+  };
+}) satisfies Handler;
+
+const framesWithExplicitState = createFrames<{
+  test: boolean;
+}>({});
+framesWithExplicitState(async ctx => {
+  ctx.state satisfies {
+    test: boolean;
+  };
+  ctx.initialState satisfies {
+    test: boolean;
+  };
+  ctx satisfies {
+    message?: any;
+    pressedButton?: any;
+    request: Request;
+  }
+
+  return {
+    image: 'http://test.png'
+  };
+}) satisfies Handler;

--- a/packages/frames.js/src/remix/index.test.ts
+++ b/packages/frames.js/src/remix/index.test.ts
@@ -7,4 +7,33 @@ describe("remix adapter", () => {
       expect(lib).toHaveProperty(exportName);
     }
   );
+
+  it("correctly integrates with remix", async () => {
+    type State = {
+      test: boolean;
+    };
+    const frames = lib.createFrames<State>({
+      initialState: {
+        test: false,
+      },
+    });
+
+    const handleRequest = frames(async (ctx) => {
+      expect(ctx.state).toEqual({ test: false });
+
+      return {
+        image: "http://test.png",
+        // satisfies is here so if also check if type is correct
+        state: ctx.state satisfies State,
+      };
+    });
+
+    await expect(
+      handleRequest({
+        request: new Request("http://localhost:3000"),
+        params: {},
+        context: {},
+      })
+    ).resolves.toHaveProperty("status", 200);
+  });
 });

--- a/packages/frames.js/src/remix/test.types.tsx
+++ b/packages/frames.js/src/remix/test.types.tsx
@@ -1,0 +1,51 @@
+import { ActionFunction, LoaderFunction } from '@remix-run/node';
+import { createFrames, types } from '.';
+
+type Handler = LoaderFunction | ActionFunction;
+
+const framesWithoutState = createFrames();
+framesWithoutState(async ctx => {
+  ctx.initialState satisfies types.JsonValue | undefined;
+  ctx.state satisfies types.JsonValue | undefined;
+
+  return {
+    image: 'http://test.png'
+  };
+}) satisfies Handler;
+
+const framesWithInferredState = createFrames({
+  initialState: {
+    test: true
+  }
+});
+framesWithInferredState(async ctx => {
+  ctx.initialState satisfies { test: boolean; };
+  ctx.state satisfies {
+    test: boolean;
+  };
+
+  return {
+    image: 'http://test.png'
+  };
+}) satisfies Handler;
+
+const framesWithExplicitState = createFrames<{
+  test: boolean;
+}>({});
+framesWithExplicitState(async ctx => {
+  ctx.state satisfies {
+    test: boolean;
+  };
+  ctx.initialState satisfies {
+    test: boolean;
+  };
+  ctx satisfies {
+    message?: any;
+    pressedButton?: any;
+    request: Request;
+  }
+
+  return {
+    image: 'http://test.png'
+  };
+}) satisfies Handler;

--- a/packages/frames.js/tsup.config.ts
+++ b/packages/frames.js/tsup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   format: ["cjs", "esm"],
   clean: true,
   entry: glob.sync("src/**/*.{ts,tsx}", {
-    ignore: ["**/*.test.{ts,tsx}", "**/*.snap"],
+    ignore: ["**/*.test.{ts,tsx}", "**/*.snap", "**/test.types.{ts,tsx}"],
     onlyFiles: true,
     cwd: dirname(fileURLToPath(import.meta.url)),
   }),

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,8 @@
     "dev": {
       "cache": false,
       "persistent": true
-    }
+    },
+    "typecheck": {}
   },
   "globalEnv": [
     "NODE_ENV",


### PR DESCRIPTION
## Change Summary

This PR fixes how `createFrames()` function is defined. Now it takes first generic parameter as State. 

PR also adds type tests so we can at least be sure that the API works fine on type level.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
