### PR TITLE
fix: use correct version of debugger in templates and also upgrade valid ones

### DIFF
--- a/.changeset/orange-owls-agree.md
+++ b/.changeset/orange-owls-agree.md
@@ -1,0 +1,5 @@
+---
+"create-frames": patch
+---
+
+fix: debugger dependency version

--- a/templates/cloudflare-worker/package.json
+++ b/templates/cloudflare-worker/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.1.0",
     "@cloudflare/workers-types": "^4.20240320.1",
-    "@frames.js/debugger": "^0.1.9",
+    "@frames.js/debugger": "^0.1.13",
     "@types/node": "^18.17.0",
     "@types/react": "^18.2.45",
     "concurrently": "^8.2.2",

--- a/templates/express/package.json
+++ b/templates/express/package.json
@@ -11,7 +11,7 @@
     "sirv": "^2.0.4"
   },
   "devDependencies": {
-    "@frames.js/debugger": "^0.1.9",
+    "@frames.js/debugger": "^0.1.13",
     "@types/express": "^4.17.21",
     "@types/node": "^18.17.0",
     "@types/react": "^18.2.45",

--- a/templates/hono/package.json
+++ b/templates/hono/package.json
@@ -10,7 +10,7 @@
     "react": "^18.2.0"
   },
   "devDependencies": {
-    "@frames.js/debugger": "^0.1.9",
+    "@frames.js/debugger": "^0.1.13",
     "@hono/vite-dev-server": "^0.10.0",
     "@types/node": "^18.17.0",
     "@types/react": "^18.2.45",

--- a/templates/next-starter-with-examples/package.json
+++ b/templates/next-starter-with-examples/package.json
@@ -26,7 +26,7 @@
     "node": ">=18.17.0"
   },
   "devDependencies": {
-    "@frames.js/debugger": "^0.1.9",
+    "@frames.js/debugger": "^0.1.13",
     "@types/node": "^18.17.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",

--- a/templates/next-utils-starter/package.json
+++ b/templates/next-utils-starter/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^14.0.4",
-    "@frames.js/debugger": "^0.1.9",
+    "@frames.js/debugger": "^0.1.13",
     "@types/eslint": "^8.56.1",
     "@types/node": "^20.10.6",
     "@types/react": "^18.2.46",

--- a/templates/next/package.json
+++ b/templates/next/package.json
@@ -13,7 +13,7 @@
     "@types/node": "^18.17.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
-    "@frames.js/debugger": "^",
+    "@frames.js/debugger": "^0.1.13",
     "concurrently": "^8.2.2",
     "typescript": "^5.3.3"
   },

--- a/templates/remix/package.json
+++ b/templates/remix/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@frames.js/debugger": "^0.1.9",
+    "@frames.js/debugger": "^0.1.13",
     "@remix-run/dev": "^2.8.1",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",


### PR DESCRIPTION
## Change Summary

This PR fixes invalid dependency in `next` template and also upgrades the rest.

Closes #264 

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
