### PR TITLE
fix: prevent double load of initial frame

### DIFF
--- a/.changeset/plenty-bananas-cry.md
+++ b/.changeset/plenty-bananas-cry.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/render": patch
+---
+
+fix: prevent double load of initial frame


### PR DESCRIPTION
## Change Summary

This PR fixes an issue when initial frame was always loaded twice because effect has been fired twice.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
