### PR TITLE
fix: next.js generateMetadata example code

### DIFF
--- a/.changeset/clean-dragons-doubt.md
+++ b/.changeset/clean-dragons-doubt.md
@@ -1,0 +1,5 @@
+---
+"docs": minor
+---
+
+fix: next.js generateMetadata example code

--- a/docs/pages/reference/core/next/index.mdx
+++ b/docs/pages/reference/core/next/index.mdx
@@ -34,10 +34,13 @@ import { fetchMetadata } from "frames.js/next";
 export async function generateMetadata() {
   return {
     title: "My page",
-    // provide full URL to your /frames endpoint
-    ...(await fetchMetadata(
-      new URL("/frames", process.env.VERCEL_URL || "http://localhost:3000")
-    )),
+    other: {
+      // ...
+      ...(await fetchMetadata(
+        // provide full URL to your /frames endpoint
+        new URL("/frames", process.env.VERCEL_URL || "http://localhost:3000")
+      )),
+    }
   };
 }
 


### PR DESCRIPTION
## Change Summary
In the Next.js App Router integration reference, the data awaited from `fetchMetadata` in the `generateMetadata()` function is not put under the `other` attribute, causing errors when rendering the frame. Fixed by following the format found in the Quickstart guide.

## Merge Checklist

- [X] PR has a [Changeset](CONTRIBUTING.md)
- [X] PR includes documentation if necessary
- [X] PR updates the boilerplates if necessary
