### PR TITLE
fix: escape user provided HTML attribute values

### DIFF
--- a/.changeset/fast-lemons-hug.md
+++ b/.changeset/fast-lemons-hug.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix: escape serialized state in html

--- a/packages/frames.js/src/getFrameHtml.test.ts
+++ b/packages/frames.js/src/getFrameHtml.test.ts
@@ -1,0 +1,83 @@
+import { getFrame } from "./getFrame";
+import { getFrameHtmlHead } from "./getFrameHtml";
+import type { Frame } from "./types";
+
+describe("getFrameHtmlHead", () => {
+  it("correctly serializes JSON containing single quotes", () => {
+    const json = { test: "'><&" };
+    const frame: Frame = {
+      image: "https://example.com/image.jpg",
+      version: "vNext",
+      state: JSON.stringify(json),
+    };
+
+    const html = getFrameHtmlHead(frame);
+
+    expect(html).toContain(
+      '<meta name="fc:frame:state" content="{&quot;test&quot;:&quot;&#39;&gt;&lt;&&quot;}"/>'
+    );
+
+    const result = getFrame({ htmlString: html, url: "http://framesjs.org" });
+
+    expect(result.frame).toMatchObject(frame);
+    expect(JSON.parse(result.frame.state as unknown as string)).toEqual(json);
+  });
+
+  it("correctly serializes JSON containing double quotes", () => {
+    const json = { test: '"><&' };
+    const frame: Frame = {
+      image: "https://example.com/image.jpg",
+      version: "vNext",
+      state: JSON.stringify(json),
+    };
+
+    const html = getFrameHtmlHead(frame);
+
+    expect(html).toContain(
+      '<meta name="fc:frame:state" content="{&quot;test&quot;:&quot;\\&quot;&gt;&lt;&&quot;}"/>'
+    );
+
+    const result = getFrame({ htmlString: html, url: "http://framesjs.org" });
+
+    expect(result.frame).toMatchObject(frame);
+    expect(JSON.parse(result.frame.state as unknown as string)).toEqual(json);
+  });
+
+  it("correctly serializes and deserializes text input containing single quotes", () => {
+    const inputText = "'test''''";
+    const frame: Frame = {
+      image: "https://example.com/image.jpg",
+      version: "vNext",
+      inputText,
+    };
+
+    const html = getFrameHtmlHead(frame);
+
+    expect(html).toContain(
+      '<meta name="fc:frame:input:text" content="&#39;test&#39;&#39;&#39;&#39;"/>'
+    );
+
+    const result = getFrame({ htmlString: html, url: "http://framesjs.org" });
+
+    expect(result.frame).toMatchObject(frame);
+  });
+
+  it("correctly serializes and deserializes text input containing double quoes", () => {
+    const inputText = '"test""""';
+    const frame: Frame = {
+      image: "https://example.com/image.jpg",
+      version: "vNext",
+      inputText,
+    };
+
+    const html = getFrameHtmlHead(frame);
+
+    expect(html).toContain(
+      '<meta name="fc:frame:input:text" content="&quot;test&quot;&quot;&quot;&quot;"/>'
+    );
+
+    const result = getFrame({ htmlString: html, url: "http://framesjs.org" });
+
+    expect(result.frame).toMatchObject(frame);
+  });
+});

--- a/packages/frames.js/src/getFrameHtml.ts
+++ b/packages/frames.js/src/getFrameHtml.ts
@@ -1,4 +1,5 @@
 import type { Frame } from "./types";
+import { escapeHtmlAttributeValue } from "./utils";
 
 export interface GetFrameHtmlOptions {
   /** value for the OG "og:title" html tag*/
@@ -25,7 +26,11 @@ export function getFrameHtml(
   <html>
     <head>
       <title>${options.title ?? "frame"}</title>
-      ${options.og?.title ? `<meta property="og:title" content="${options.og.title}"/>` : ""}
+      ${
+        options.og?.title
+          ? `<meta property="og:title" content="${options.og.title}"/>`
+          : ""
+      }
       ${getFrameHtmlHead(frame)}
       ${options.htmlHead || ""}
     </head>
@@ -45,21 +50,35 @@ export function getFrameHtmlHead(frame: Frame): string {
     `<meta name="fc:frame" content="${frame.version}"/>`,
     `<meta name="fc:frame:image" content="${frame.image}"/>`,
     `<meta name="fc:frame:post_url" content="${frame.postUrl}"/>`,
-    frame.state ? `<meta name="fc:frame:state" content='${frame.state}'/>` : "",
+    frame.state
+      ? `<meta name="fc:frame:state" content="${escapeHtmlAttributeValue(
+          frame.state
+        )}"/>`
+      : "",
     frame.imageAspectRatio
       ? `<meta name="fc:frame:image:aspect_ratio" content="${frame.imageAspectRatio}"/>`
       : "",
     frame.inputText
-      ? `<meta name="fc:frame:input:text" content="${frame.inputText}"/>`
+      ? `<meta name="fc:frame:input:text" content="${escapeHtmlAttributeValue(
+          frame.inputText
+        )}"/>`
       : "",
     ...(frame.buttons?.flatMap((button, index) => [
-      `<meta name="fc:frame:button:${index + 1}" content="${button.label}"/>`,
-      `<meta name="fc:frame:button:${index + 1}:action" content="${button.action}"/>`,
+      `<meta name="fc:frame:button:${
+        index + 1
+      }" content="${escapeHtmlAttributeValue(button.label)}"/>`,
+      `<meta name="fc:frame:button:${index + 1}:action" content="${
+        button.action
+      }"/>`,
       button.target
-        ? `<meta name="fc:frame:button:${index + 1}:target" content="${button.target}"/>`
+        ? `<meta name="fc:frame:button:${index + 1}:target" content="${
+            button.target
+          }"/>`
         : "",
       button.action === "tx" && button.post_url
-        ? `<meta name="fc:frame:button:${index + 1}:post_url" content="${button.post_url}"/>`
+        ? `<meta name="fc:frame:button:${index + 1}:post_url" content="${
+            button.post_url
+          }"/>`
         : "",
     ]) ?? []),
   ];
@@ -70,21 +89,35 @@ export function getFrameHtmlHead(frame: Frame): string {
         `<meta name="of:version" content="${frame.version}"/>`,
         `<meta name="of:image" content="${frame.image}"/>`,
         `<meta name="of:post_url" content="${frame.postUrl}"/>`,
-        frame.state ? `<meta name="of:state" content='${frame.state}'/>` : "",
+        frame.state
+          ? `<meta name="of:state" content="${escapeHtmlAttributeValue(
+              frame.state
+            )}"/>`
+          : "",
         frame.imageAspectRatio
           ? `<meta name="of:image:aspect_ratio" content="${frame.imageAspectRatio}"/>`
           : "",
         frame.inputText
-          ? `<meta name="of:input:text" content="${frame.inputText}"/>`
+          ? `<meta name="of:input:text" content="${escapeHtmlAttributeValue(
+              frame.inputText
+            )}"/>`
           : "",
         ...(frame.buttons?.flatMap((button, index) => [
-          `<meta name="of:button:${index + 1}" content="${button.label}"/>`,
-          `<meta name="of:button:${index + 1}:action" content="${button.action}"/>`,
+          `<meta name="of:button:${
+            index + 1
+          }" content="${escapeHtmlAttributeValue(button.label)}"/>`,
+          `<meta name="of:button:${index + 1}:action" content="${
+            button.action
+          }"/>`,
           button.target
-            ? `<meta name="of:button:${index + 1}:target" content="${button.target}"/>`
+            ? `<meta name="of:button:${index + 1}:target" content="${
+                button.target
+              }"/>`
             : "",
           button.action === "tx" && button.post_url
-            ? `<meta name="of:button:${index + 1}:post_url" content="${button.post_url}"/>`
+            ? `<meta name="of:button:${index + 1}:post_url" content="${
+                button.post_url
+              }"/>`
             : "",
         ]) ?? []),
       ],

--- a/packages/frames.js/src/utils.ts
+++ b/packages/frames.js/src/utils.ts
@@ -94,7 +94,7 @@ export function isValidVersion(version: string): boolean {
 
 export function getEnumKeyByEnumValue<
   TEnumKey extends string,
-  TEnumVal extends string | number,
+  TEnumVal extends string | number
 >(
   enumDefinition: { [key in TEnumKey]: TEnumVal },
   enumValue: TEnumVal
@@ -117,7 +117,9 @@ export function extractAddressFromJSONMessage(
 
   if (data.type !== MessageType.VERIFICATION_ADD_ETH_ADDRESS) {
     throw new Error(
-      `Invalid message provided. Expected message type to be ${MessageType.VERIFICATION_ADD_ETH_ADDRESS} but got ${getEnumKeyByEnumValue(MessageType, data.type)}.`
+      `Invalid message provided. Expected message type to be ${
+        MessageType.VERIFICATION_ADD_ETH_ADDRESS
+      } but got ${getEnumKeyByEnumValue(MessageType, data.type)}.`
     );
   }
 
@@ -143,4 +145,24 @@ export function extractAddressFromJSONMessage(
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- we know the data is there
   return (message as Record<string, any>).data.verificationAddAddressBody
     .address as `0x${string}`;
+}
+
+/**
+ * Used to make sure that the provided value does not cause parsing issues malforming the value.
+ */
+export function escapeHtmlAttributeValue(value: string): string {
+  return value.replace(/["'<>]/g, (char) => {
+    switch (char) {
+      case '"':
+        return "&quot;";
+      case "'":
+        return "&#39;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      default:
+        return char;
+    }
+  });
 }


### PR DESCRIPTION
## Change Summary

This PR properly escapes user provided HTML attribute values. This for example fixes an issue when state value contains double quotes or single quotes, etc. All proper HTML parsers should be able to decode the values properly.

https://linear.app/modprotocol/issue/FRA-176/bug-report-with-deserializing-state

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
