### PR TITLE
fix: cloudflare worker template start command

### DIFF
--- a/.changeset/sweet-carrots-cross.md
+++ b/.changeset/sweet-carrots-cross.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/debugger": patch
+---
+
+fix: cloudflare worker starter script command

--- a/templates/cloudflare-worker/package.json
+++ b/templates/cloudflare-worker/package.json
@@ -40,7 +40,7 @@
     "dev": "concurrently --kill-others \"wrangler dev\" \"frames --url http://localhost:8787\"",
     "deploy": "wrangler deploy",
     "build": "wrangler deploy --dry-run",
-    "start": "wangler dev",
+    "start": "wrangler dev",
     "test": "vitest"
   }
 }


### PR DESCRIPTION
## Change Summary

This PR fixes invalid `start` command in cloudflare worker template

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
