### PR TITLE
fix: lock next version, move react do production dependencies

### DIFF
--- a/.changeset/fast-flies-help.md
+++ b/.changeset/fast-flies-help.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/debugger": patch
+---
+
+fix: lock nextjs version, move react/react-dom to dependencies

--- a/packages/debugger/app/components/create-signer.tsx
+++ b/packages/debugger/app/components/create-signer.tsx
@@ -7,7 +7,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { FarcasterSigner } from "frames.js/render";
+import type { FarcasterSigner } from "@frames.js/render";
 import QRCode from "qrcode.react";
 
 const LoginWindow = ({

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -17,8 +17,10 @@
   },
   "dependencies": {
     "is-port-reachable": "^4.0.0",
-    "next": "^14.1.3",
+    "next": "14.1.4",
     "open": "^10.0.3",
+    "react-dom": "^18.2.0",
+    "react": "^18.2.0",
     "yargs": "^17.7.2"
   },
   "engines": {
@@ -52,8 +54,6 @@
     "lucide-react": "^0.344.0",
     "postcss": "^8",
     "qrcode.react": "^3.1.0",
-    "react-dom": "^18.2.0",
-    "react": "^18.2.0",
     "rimraf": "^5.0.5",
     "tailwind-merge": "^2.2.1",
     "tailwindcss-animate": "^1.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11188,7 +11188,7 @@ neverthrow@^6.0.0:
   resolved "https://registry.yarnpkg.com/neverthrow/-/neverthrow-6.1.0.tgz#51a6e9ce2e06600045b3c1b37aecc536d267bf95"
   integrity sha512-xNbNjp/6M5vUV+mststgneJN9eJeJCDSYSBTaf3vxgvcKooP+8L0ATFpM8DGfmH7UWKJeoa24Qi33tBP9Ya3zA==
 
-next@^14.0.4, next@^14.1.0, next@^14.1.2, next@^14.1.3:
+next@14.1.4, next@^14.0.4, next@^14.1.0, next@^14.1.2:
   version "14.1.4"
   resolved "https://registry.yarnpkg.com/next/-/next-14.1.4.tgz#203310f7310578563fd5c961f0db4729ce7a502d"
   integrity sha512-1WTaXeSrUwlz/XcnhGTY7+8eiaFvdet5z9u3V2jb+Ek1vFo0VhHKSAIJvDWfQpttWjnyw14kBeq28TPq7bTeEQ==


### PR DESCRIPTION
## Change Summary

This PR locks `next` version used in `debugger` because `14.2.x` versions are broken and cause debugger to fail completely.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
