### PR TITLE
fix: update images worker default container styling

### DIFF
--- a/.changeset/rude-snakes-act.md
+++ b/.changeset/rude-snakes-act.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix: set default images worker styling font size to 36px

--- a/packages/frames.js/src/middleware/images-worker/next/index.tsx
+++ b/packages/frames.js/src/middleware/images-worker/next/index.tsx
@@ -75,7 +75,7 @@ export function createImagesWorker(
 function Scaffold({ children }: { children: React.ReactNode }): ReactElement {
   return (
     <div tw="flex flex-row items-stretch relative w-full h-screen bg-white overflow-hidden">
-      <div tw="flex flex-col w-full justify-center items-center text-black overflow-hidden">
+      <div tw="flex flex-col w-full justify-center items-center text-black text-[36px] overflow-hidden">
         {children}
       </div>
     </div>


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Updates the default font size in the images worker default container styling to match default inline image rendering

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
