### PR TITLE
feat: allow to override default debugger url

### DIFF
--- a/.changeset/happy-trainers-film.md
+++ b/.changeset/happy-trainers-film.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/debugger": patch
+---
+
+feat: allow to override default url in debugger

--- a/packages/debugger/app/page.tsx
+++ b/packages/debugger/app/page.tsx
@@ -25,7 +25,7 @@ const LoginWindow = dynamic(() => import("./components/create-signer"), {
   ssr: false,
 });
 
-const FALLBACK_URL = process.env.NEXT_PUBLIC_HOST || 'http://localhost:3000';
+const FALLBACK_URL = process.env.NEXT_PUBLIC_DEBUGGER_DEFAULT_URL || 'http://localhost:3000';
 
 export default function App({
   searchParams,


### PR DESCRIPTION
## Change Summary

This PR adds an option to override default debugger URL to something else than `NEXT_PUBLIC_HOST`. 

To override the URL, set up the `NEXT_PUBLIC_DEBUGGER_DEFAULT_URL` to full url. In our case `https://framesjs.org` so hosted debugger will point to functional frame.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
