### PR TITLE
fix: include state in untrusted data

### DIFF
--- a/.changeset/wet-files-wash.md
+++ b/.changeset/wet-files-wash.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/render": patch
+---
+
+fix: include frame state in untrusted data

--- a/packages/render/src/farcaster/frames.tsx
+++ b/packages/render/src/farcaster/frames.tsx
@@ -1,19 +1,15 @@
-import type {
-  CastId,
-  FrameActionMessage
-} from "@farcaster/core";
+import type { CastId, FrameActionMessage } from "@farcaster/core";
 import {
+  FarcasterNetwork,
+  FrameActionBody,
+  Message,
   NobleEd25519Signer,
   makeFrameAction,
-  FarcasterNetwork,
-  Message,
-  FrameActionBody
 } from "@farcaster/core";
-import { hexToBytes } from "viem";
 import type { FrameButton } from "frames.js";
+import { hexToBytes } from "viem";
 import type { FrameContext } from "../types";
 import type { FarcasterSignerState } from "./signers";
-
 
 export type FarcasterFrameContext = {
   /** Connected address of user, only sent with transaction data request */
@@ -101,6 +97,7 @@ export const signFrameAction = async ({
         inputText,
         address: frameContext.connectedAddress,
         transactionId,
+        state,
       },
       trustedData: {
         messageBytes: trustedBytes,


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Fix a bug in `@frames.js/render` where state was not included in untrusted data.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
