### PR TITLE
fix: lock neverthrow package version until it is fixed

### DIFF
--- a/.changeset/tame-eels-drop.md
+++ b/.changeset/tame-eels-drop.md
@@ -1,0 +1,6 @@
+---
+"@frames.js/debugger": patch
+"@frames.js/render": patch
+---
+
+fix: lock neverthrow version until it is fixed upstream

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -87,6 +87,19 @@
     "viem": "^2.7.12",
     "wagmi": "^2.5.7"
   },
+  "resolutions": {
+    "neverthrow": "6.1.0"
+  },
+  "overrides": {
+    "@farcaster/core": {
+      "neverthrow": "6.1.0"
+    }
+  },
+  "pnpm": {
+    "overrides": {
+      "neverthrow": "6.1.0"
+    }
+  },
   "engineStrict": true,
   "scripts": {
     "dev": "next dev -p 3010",

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -85,5 +85,18 @@
   "dependencies": {
     "@farcaster/core": "^0.14.7",
     "frames.js": "^0.14.0"
+  },
+  "resolutions": {
+    "neverthrow": "6.1.0"
+  },
+  "overrides": {
+    "@farcaster/core": {
+      "neverthrow": "6.1.0"
+    }
+  },
+  "pnpm": {
+    "overrides": {
+      "neverthrow": "6.1.0"
+    }
   }
 }


### PR DESCRIPTION
## Change Summary

This PR locks `neverthrow` version to `6.1.0` because `6.2.0` is missing `dist` folder. The package is subdependency of `@farcaster/core`.

See https://github.com/supermacro/neverthrow/issues/532

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
