### PR TITLE
fix: persists unmodified frame state between frames

### DIFF
--- a/.changeset/modern-steaks-reflect.md
+++ b/.changeset/modern-steaks-reflect.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix: pass previous state if it exists and is not modified in frames response

--- a/packages/frames.js/src/middleware/stateMiddleware.test.ts
+++ b/packages/frames.js/src/middleware/stateMiddleware.test.ts
@@ -47,4 +47,18 @@ describe("stateMiddleware", () => {
 
     expect(next).toHaveBeenCalledWith({ state: { initial: true } });
   });
+
+  it("includes previous state in the result if it is not present", async () => {
+    const state = { foo: "bar" };
+    const ctx = {
+      message: { state: JSON.stringify(state) },
+      initialState: {},
+    };
+    const mw = stateMiddleware();
+    const next = jest.fn().mockReturnValue({ image: "/test" });
+
+    const result = await mw(ctx as unknown as FramesContext, next);
+
+    expect(result).toEqual({ image: "/test", state });
+  });
 });

--- a/packages/frames.js/src/middleware/stateMiddleware.ts
+++ b/packages/frames.js/src/middleware/stateMiddleware.ts
@@ -1,4 +1,5 @@
 import type { FramesMiddleware, JsonValue } from "../core/types";
+import { isFrameDefinition } from "../core/utils";
 
 type StateMiddlewareContext<TState extends JsonValue | undefined> = {
   /**
@@ -43,9 +44,19 @@ export function stateMiddleware<
         }
       }
 
-      return next({
+      const nextResult = await next({
         state,
       });
+
+      if (isFrameDefinition(nextResult)) {
+        // Include previous state if it is not present in the result
+        return {
+          state,
+          ...nextResult,
+        };
+      }
+
+      return nextResult;
     }
 
     return next({


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Set previous frame state in frame response if it is set in request but is not returned in frame definition return value.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
