### PR TITLE
fix: image worker options

### DIFF
--- a/.changeset/pretty-jobs-move.md
+++ b/.changeset/pretty-jobs-move.md
@@ -1,5 +1,0 @@
----
-"frames.js": patch
----
-
-fix: merge images worker image options with width and height

--- a/.changeset/pretty-jobs-move.md
+++ b/.changeset/pretty-jobs-move.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix: merge images worker image options with width and height

--- a/.changeset/tall-beans-hunt.md
+++ b/.changeset/tall-beans-hunt.md
@@ -1,0 +1,5 @@
+---
+"frames.js": minor
+---
+
+fix: Breaking! Images Worker image options now accept sizes by supported aspect ratio instead of a single width and height

--- a/packages/frames.js/src/middleware/images-worker/next/createImagesWorker.test.tsx
+++ b/packages/frames.js/src/middleware/images-worker/next/createImagesWorker.test.tsx
@@ -89,8 +89,16 @@ describe("createImagesWorker", () => {
 
     const imagesRoute = createImagesWorker({
       imageOptions: {
-        width: 100,
-        height: 100,
+        sizes: {
+          "1:1": {
+            width: 100,
+            height: 100,
+          },
+          "1.91:1": {
+            width: 191,
+            height: 100,
+          },
+        },
       },
     });
 

--- a/packages/frames.js/src/middleware/images-worker/next/index.tsx
+++ b/packages/frames.js/src/middleware/images-worker/next/index.tsx
@@ -6,12 +6,19 @@ import type { SerializedNode } from "..";
 import { deserializeJsx, verifySignature } from "..";
 import type { ImageAspectRatio } from "../../../types";
 
+type ImageWorkerImageOptions = Omit<
+  ImageResponseOptions,
+  "width" | "height"
+> & {
+  sizes?: Record<ImageAspectRatio, { width: number; height: number }>;
+};
+
 export function createImagesWorker(
   options: {
     /** The secret used to sign the jsx payload, if not specified no authentication checks will be done */
     secret?: string;
     /** Image options to pass the default image renderer (`\@vercel/og`) */
-    imageOptions?: ImageResponseOptions;
+    imageOptions?: ImageWorkerImageOptions;
   } = {}
 ): (
   /**
@@ -51,25 +58,24 @@ export function createImagesWorker(
       const aspectRatio = (url.searchParams.get("aspectRatio") ||
         "1.91:1") as ImageAspectRatio;
 
+      if (aspectRatio !== "1:1" && aspectRatio !== "1.91:1") {
+        throw new Error("Invalid aspect ratio");
+      }
+
       if (jsxToResponse) {
         const response = await jsxToResponse(jsx, { aspectRatio });
         return response;
       }
 
-      const height = 600;
-      const width =
-        aspectRatio === "1.91:1" ? Math.round(height * 1.91) : height;
-
-      const {
-        width: overrideWidth,
-        height: overrideHeight,
-        ...overrideOptions
-      } = options.imageOptions || {};
+      const defaultSizes: ImageWorkerImageOptions["sizes"] = {
+        "1:1": { width: 1146, height: 1146 },
+        "1.91:1": { width: 1146, height: 600 },
+      };
+      const sizes = { ...defaultSizes, ...options.imageOptions?.sizes };
 
       return new ImageResponse(<Scaffold>{jsx}</Scaffold>, {
-        width: overrideWidth || width,
-        height: overrideHeight || height,
-        ...overrideOptions,
+        ...options.imageOptions,
+        ...sizes[aspectRatio],
       }) as Response;
     };
   };

--- a/packages/frames.js/src/middleware/images-worker/next/index.tsx
+++ b/packages/frames.js/src/middleware/images-worker/next/index.tsx
@@ -60,13 +60,17 @@ export function createImagesWorker(
       const width =
         aspectRatio === "1.91:1" ? Math.round(height * 1.91) : height;
 
-      return new ImageResponse(
-        <Scaffold>{jsx}</Scaffold>,
-        options.imageOptions || {
-          width,
-          height,
-        }
-      ) as Response;
+      const {
+        width: overrideWidth,
+        height: overrideHeight,
+        ...overrideOptions
+      } = options.imageOptions || {};
+
+      return new ImageResponse(<Scaffold>{jsx}</Scaffold>, {
+        width: overrideWidth || width,
+        height: overrideHeight || height,
+        ...overrideOptions,
+      }) as Response;
     };
   };
 }


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Allow the user to specify fonts in image options without specifying dimensions.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
