### PR TITLE
Revert "fix: lock neverthrow package version until it is fixed"

### DIFF
--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -66,19 +66,6 @@
     "viem": "^2.7.12",
     "wagmi": "^2.5.7"
   },
-  "resolutions": {
-    "neverthrow": "6.1.0"
-  },
-  "overrides": {
-    "@farcaster/core": {
-      "neverthrow": "6.1.0"
-    }
-  },
-  "pnpm": {
-    "overrides": {
-      "neverthrow": "6.1.0"
-    }
-  },
   "engineStrict": true,
   "scripts": {
     "dev": "next dev -p 3010",

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -85,18 +85,5 @@
   "dependencies": {
     "@farcaster/core": "^0.14.7",
     "frames.js": "^0.14.0"
-  },
-  "resolutions": {
-    "neverthrow": "6.1.0"
-  },
-  "overrides": {
-    "@farcaster/core": {
-      "neverthrow": "6.1.0"
-    }
-  },
-  "pnpm": {
-    "overrides": {
-      "neverthrow": "6.1.0"
-    }
   }
 }


### PR DESCRIPTION
Reverts framesjs/frames.js#329 because the issue was resolved upstream. https://github.com/supermacro/neverthrow/issues/532