### PR TITLE
fix: exclude `address` from frame context in post button handler

### DIFF
--- a/.changeset/blue-pigs-deliver.md
+++ b/.changeset/blue-pigs-deliver.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/render": patch
+---
+
+fix: only include address context in transaction requests

--- a/packages/render/src/types.ts
+++ b/packages/render/src/types.ts
@@ -69,7 +69,8 @@ export interface SignerStateInstance<
     state?: string;
     transactionId?: `0x${string}`;
     address?: `0x${string}`;
-    frameContext: FrameContextType;
+    /** Transacting address is not included in non-transaction frame actions */
+    frameContext: FrameContextType | Omit<FrameContextType, "address">;
   }) => Promise<{
     body: FrameActionBodyType;
     searchParams: URLSearchParams;

--- a/packages/render/src/use-frame.tsx
+++ b/packages/render/src/use-frame.tsx
@@ -529,10 +529,14 @@ export function useFrame<
       return;
     }
 
+    const requiredFrameContext = { ...frameContext };
+    // Address is not included in post action
+    delete requiredFrameContext.address;
+
     const frameSignatureContext = {
       inputText: postInputText,
       signer: signerState.signer ?? null,
-      frameContext,
+      frameContext: requiredFrameContext,
       url: homeframeUrl,
       target,
       frameButton,

--- a/packages/render/src/use-frame.tsx
+++ b/packages/render/src/use-frame.tsx
@@ -529,9 +529,8 @@ export function useFrame<
       return;
     }
 
-    const requiredFrameContext = { ...frameContext };
-    // Address is not included in post action
-    delete requiredFrameContext.address;
+    // Transacting address is not included in post action
+    const { address: _, ...requiredFrameContext } = frameContext;
 
     const frameSignatureContext = {
       inputText: postInputText,


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Excludes `address` from frame context in post button handler

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
