### PR TITLE
fix: do not hoist docs dependencies

### DIFF
--- a/.changeset/pink-rings-fetch.md
+++ b/.changeset/pink-rings-fetch.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+fix: nohoist docs dependencies to fix client side dev bundle

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,6 +13,12 @@
     "next": "^14.1.0",
     "react": "latest",
     "react-dom": "latest",
-    "vocs": "1.0.0-alpha.42"
+    "vocs": "1.0.0-alpha.46"
+  },
+  "workspaces": {
+    "nohoist": [
+      "vocs",
+      "vocs/**"
+    ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13480,7 +13480,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13587,7 +13596,14 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -14765,10 +14781,10 @@ vitest@1.3.0:
     vite-node "1.3.0"
     why-is-node-running "^2.2.2"
 
-vocs@1.0.0-alpha.42:
-  version "1.0.0-alpha.42"
-  resolved "https://registry.yarnpkg.com/vocs/-/vocs-1.0.0-alpha.42.tgz#92a594cdeee41e39d4250adefed10323ff587d3d"
-  integrity sha512-6ZAbN6dE9wb6N5Jw8Lt/p4Sn1YPN6RBuM5LHCdPQvfsMB+eA5Lh45mU3cc5Ho56W1jS94aJwvUfvHjRZyVB5FQ==
+vocs@1.0.0-alpha.46:
+  version "1.0.0-alpha.46"
+  resolved "https://registry.yarnpkg.com/vocs/-/vocs-1.0.0-alpha.46.tgz#3df1929267125b700f9ec010cc4bec2b142584be"
+  integrity sha512-iqhHCLUnmC/b9SAVcEEVFZR2K/HdyKzI80KXA5e4i5agHTG1i+J2aS72sNfqaDrWDCMFZe2Ug92Qve+WNCcQyw==
   dependencies:
     "@floating-ui/react" "^0.26.6"
     "@hono/node-server" "^1.2.3"
@@ -15042,7 +15058,7 @@ wrangler@3.39.0, wrangler@^3.39.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -15055,6 +15071,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Change Summary

This PR fixes docs dependencies to be `nohoist` since there is a conflict in packages causing dev client side js to be broken.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
