### PR TITLE
fix: lock next version in templates

### DIFF
--- a/.changeset/hungry-pears-yell.md
+++ b/.changeset/hungry-pears-yell.md
@@ -1,0 +1,8 @@
+---
+"template-next-starter-with-examples": patch
+"template-next-utils-starter": patch
+"template-next": patch
+"create-frames": patch
+---
+
+fix: lock next version to 14.1.4 in templates

--- a/templates/next-starter-with-examples/package.json
+++ b/templates/next-starter-with-examples/package.json
@@ -15,7 +15,7 @@
     "@xmtp/frames-validator": "^0.5.0",
     "clsx": "^2.1.0",
     "frames.js": "^0.14.1",
-    "next": "^14.1.0",
+    "next": "14.1.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "tailwindcss-animate": "^1.0.7"

--- a/templates/next-utils-starter/package.json
+++ b/templates/next-utils-starter/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "frames.js": "^0.14.1",
-    "next": "^14.0.4",
+    "next": "14.1.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/templates/next/package.json
+++ b/templates/next/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "dependencies": {
     "frames.js": "^0.14.1",
-    "next": "^14.1.2",
+    "next": "14.1.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
## Change Summary

This PR locks next version in templates to prevent failures causes by next 14.2.x

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
