### PR TITLE
fix: debugger delegated metadata signer

### DIFF
--- a/.changeset/swift-rivers-march.md
+++ b/.changeset/swift-rivers-march.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/debugger": patch
+---
+
+feat: delegate signer metadata signatures to hosted debugger by default

--- a/packages/debugger/.env.sample
+++ b/packages/debugger/.env.sample
@@ -1,3 +1,6 @@
+# (OPTIONAL) Defaults to https://debugger.framesjs.org/, set to / if you want to authenticate signers locally
+NEXT_PUBLIC_SIGNER_BASE_URL=
+
 # Example: FARCASTER_DEVELOPER_MNEMONIC="candy gibraltar foxtrot kilo barnacles foxes ..."
 # (OPTIONAL) Needed for the debugger to create a real Farcaster signer. Get this by exporting your seed phrase from the Warpcast app. Don't share that seed phrase with anyone.
 FARCASTER_DEVELOPER_MNEMONIC=

--- a/packages/debugger/app/hooks/use-farcaster-identity.tsx
+++ b/packages/debugger/app/hooks/use-farcaster-identity.tsx
@@ -227,12 +227,15 @@ export function useFarcasterIdentity(): Omit<
     try {
       const keypair = await createKeypairEDDSA();
       const keypairString = convertKeypairToHex(keypair);
-      const authorizationResponse = await fetch(`/signer`, {
-        method: "POST",
-        body: JSON.stringify({
-          publicKey: keypairString.publicKey,
-        }),
-      });
+      const authorizationResponse = await fetch(
+        `${process.env.NEXT_PUBLIC_SIGNER_BASE_URL || "https://debugger.framesjs.org/"}signer`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            publicKey: keypairString.publicKey,
+          }),
+        }
+      );
       const authorizationBody:
         | {
             signature: string;


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Delegate signer metadata signatures to hosted debugger by default to allow local use of real signers without needing to set a `FARCASTER_DEVELOPER_MNEMONIC`

Depends on #350 

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
