### PR TITLE
fix: inferred type build issue

### DIFF
--- a/.changeset/early-otters-brush.md
+++ b/.changeset/early-otters-brush.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix: inferred type build issue

--- a/packages/frames.js/src/hono/index.ts
+++ b/packages/frames.js/src/hono/index.ts
@@ -5,7 +5,7 @@ import type { CoreMiddleware } from "../middleware";
 
 export { Button, type types } from "../core";
 
-type CreateFramesForHono = types.CreateFramesFunctionDefinition<
+export type CreateFramesReturn = types.CreateFramesFunctionDefinition<
   CoreMiddleware,
   Handler
 >;
@@ -36,7 +36,7 @@ type CreateFramesForHono = types.CreateFramesFunctionDefinition<
  * ```
  */
 // @ts-expect-error -- this code is correct just function doesn't satisfy the type
-export const createFrames: CreateFramesForHono = function createFramesForHono(
+export const createFrames: CreateFramesReturn = function createFramesForHono(
   options?: types.FramesOptions<types.JsonValue | undefined, undefined>
 ) {
   const frames = coreCreateFrames(options);

--- a/packages/frames.js/src/next/index.ts
+++ b/packages/frames.js/src/next/index.ts
@@ -7,7 +7,7 @@ export { Button, type types } from "../core";
 
 export { fetchMetadata } from "./fetchMetadata";
 
-type CreateFramesForNextJS = types.CreateFramesFunctionDefinition<
+export type CreateFramesReturn = types.CreateFramesFunctionDefinition<
   CoreMiddleware,
   (req: NextRequest) => Promise<NextResponse>
 >;
@@ -37,7 +37,7 @@ type CreateFramesForNextJS = types.CreateFramesFunctionDefinition<
  * ```
  */
 // @ts-expect-error -- this is correct but the function does not satisfy the type
-export const createFrames: CreateFramesForNextJS =
+export const createFrames: CreateFramesReturn =
   function createFramesForNextJS(options?: types.FramesOptions<any, any>) {
     const frames = coreCreateFrames(options);
 

--- a/packages/frames.js/src/remix/index.ts
+++ b/packages/frames.js/src/remix/index.ts
@@ -7,7 +7,7 @@ export { Button, type types } from "../core";
 
 export { fetchMetadata } from "./fetchMetadata";
 
-type CreateFramesForRemix = types.CreateFramesFunctionDefinition<
+export type CreateFramesReturn = types.CreateFramesFunctionDefinition<
   CoreMiddleware,
   (args: LoaderFunctionArgs | ActionFunctionArgs) => Promise<Response>
 >;
@@ -37,7 +37,7 @@ type CreateFramesForRemix = types.CreateFramesFunctionDefinition<
  * ```
  */
 // @ts-expect-error -- the function works fine but somehow it does not satisfy the expected type
-export const createFrames: CreateFramesForRemix = function createFramesForRemix(
+export const createFrames: CreateFramesReturn = function createFramesForRemix(
   options?: types.FramesOptions<any, any>
 ) {
   const frames = coreCreateFrames(options);


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Fixes #352 which causes typescript compilation to fail for some versions and configurations of typescript by exporting the inferred type.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
