### PR TITLE
feat: `allowPartialFrame` option for FrameUI

### DIFF
--- a/.changeset/nine-hats-kneel.md
+++ b/.changeset/nine-hats-kneel.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/render": patch
+---
+
+feat: `allowPartialFrame` option for FrameUI

--- a/packages/debugger/app/components/frame-debugger.tsx
+++ b/packages/debugger/app/components/frame-debugger.tsx
@@ -546,6 +546,7 @@ export function FrameDebugger({
                     bg: "white",
                   }}
                   FrameImage={FrameImageNext}
+                  allowPartialFrame={true}
                 />
               </div>
               <div className="ml-auto text-sm text-slate-500">{url}</div>


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Adds an option which allows rendering a frame which may not perfectly conform to the frames spec - useful for applications like the debugger.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
