### PR TITLE
feat(debugger): detect frames.js version

### DIFF
--- a/.changeset/purple-laws-unite.md
+++ b/.changeset/purple-laws-unite.md
@@ -1,0 +1,7 @@
+---
+"frames.js": patch
+"@frames.js/debugger": patch
+"@frames.js/render": patch
+---
+
+feat: parse frames.js version from meta tags and show in debugger

--- a/packages/debugger/app/components/frame-debugger.tsx
+++ b/packages/debugger/app/components/frame-debugger.tsx
@@ -100,10 +100,16 @@ function FrameDebuggerFramePropertiesTableRow({
         visitedInvalidProperties.push(key);
     }
 
-    // @todo frame here can be Partial if there are errors we should handle that somehow
-    const flattenedFrame = getFrameFlattened(result.frame as Frame);
+    const flattenedFrame = getFrameFlattened(result.frame, {
+      "frames.js:version":
+        "frames.js:version" in result.frame && typeof result.frame["frames.js:version"] === "string"
+          ? result.frame["frames.js:version"]
+          : undefined,
+    });
 
-    delete flattenedFrame["frames.js:version"]; // TODO: get correct frames.js version
+    if (result.framesVersion) {
+      validProperties.push(["frames.js:version", result.framesVersion]);
+    }
 
     let hasExperimentalProperties = false;
 

--- a/packages/frames.js/src/getFrame.test.ts
+++ b/packages/frames.js/src/getFrame.test.ts
@@ -1,3 +1,4 @@
+import { version as framesVersion } from "../package.json";
 import { getFrame } from "./getFrame";
 import { getFrameHtml } from "./getFrameHtml";
 import type { Frame } from "./types";
@@ -110,6 +111,7 @@ describe("getFrame", () => {
         postUrl: "https://example.com/",
       },
       reports: {},
+      framesVersion: undefined,
     });
   });
 
@@ -160,6 +162,7 @@ describe("getFrame", () => {
       status: "success",
       frame: { ...exampleFrame, accepts: undefined },
       reports: {},
+      framesVersion,
     });
   });
 
@@ -236,5 +239,20 @@ describe("getFrame", () => {
     expect(JSON.parse(result.frame.state!)).toEqual({
       test: "'><&",
     });
+  });
+
+  it("should parse frames.js version from meta tags", () => {
+    const html = `
+    <meta name="frames.js:version" content="1.0.0" />
+    <meta name="fc:frame" content="vNext" />
+    <meta name="fc:frame:image" content="http://example.com/image.png" />
+    <meta name="og:image" content="http://example.com/image.png" />
+    <meta name="fc:frame:state" content="{&quot;test&quot;:&quot;&#39;&gt;&lt;&&quot;}"/>
+    <title>test</title>
+  `;
+
+    const result = getFrame({ htmlString: html, url: "https://example.com" });
+
+    expect(result.framesVersion).toEqual("1.0.0");
   });
 });

--- a/packages/frames.js/src/getFrame.ts
+++ b/packages/frames.js/src/getFrame.ts
@@ -4,7 +4,9 @@ import type {
 } from "./frame-parsers/types";
 import { parseFramesWithReports } from "./parseFramesWithReports";
 
-type GetFrameResult = ParseResult;
+type GetFrameResult = ParseResult & {
+  framesVersion?: string;
+};
 
 type GetFrameOptions = {
   htmlString: string;
@@ -33,5 +35,8 @@ export function getFrame({
     html: htmlString,
   });
 
-  return parsedFrames[specification];
+  return {
+    ...parsedFrames[specification],
+    framesVersion: parsedFrames.framesVersion,
+  };
 }

--- a/packages/frames.js/src/getFrameFlattened.ts
+++ b/packages/frames.js/src/getFrameFlattened.ts
@@ -1,12 +1,29 @@
 import { version as framesjsVersion } from "../package.json";
 import type { Frame, FrameFlattened } from "./types";
 
+export function getFrameFlattened(
+  frame: Frame,
+  overrides?: Partial<FrameFlattened>
+): FrameFlattened;
+export function getFrameFlattened(
+  frame: Partial<Frame>,
+  overrides?: Partial<FrameFlattened>
+): Partial<FrameFlattened>;
+
 /**
  * Takes a `Frame` and formats it as an intermediate step before rendering as html
- * @param frame - The `Frame` to flatten
  * @returns a plain object with frame metadata keys and values according to the frame spec, using their lengthened syntax, e.g. "fc:frame:image"
  */
-export function getFrameFlattened(frame: Frame): FrameFlattened {
+export function getFrameFlattened(
+  /**
+   * The frame to flatten
+   */
+  frame: Partial<Frame>,
+  /**
+   * Optional overrides to apply to the frame
+   */
+  overrides?: Partial<FrameFlattened>
+): Partial<FrameFlattened> {
   const openFrames =
     frame.accepts && Boolean(frame.accepts.length)
       ? {
@@ -43,7 +60,7 @@ export function getFrameFlattened(frame: Frame): FrameFlattened {
         }
       : {};
 
-  const metadata: FrameFlattened = {
+  const metadata: Partial<FrameFlattened> = {
     "fc:frame": frame.version,
     "fc:frame:image": frame.image,
     "og:image": frame.ogImage || frame.image,
@@ -67,6 +84,7 @@ export function getFrameFlattened(frame: Frame): FrameFlattened {
     ),
     ...openFrames,
     [`frames.js:version`]: framesjsVersion,
+    ...overrides,
   };
 
   return metadata;

--- a/packages/frames.js/src/parseFramesWithReports.ts
+++ b/packages/frames.js/src/parseFramesWithReports.ts
@@ -17,6 +17,8 @@ type ParseFramesWithReportsOptions = {
 
 export type ParseFramesWithReportsResult = {
   [K in SupportedParsingSpecification]: ParseResult;
+} & {
+  framesVersion?: string;
 };
 
 /**
@@ -35,6 +37,10 @@ export function parseFramesWithReports({
     fallbackPostUrl,
   });
 
+  const framesVersion = document(
+    "meta[name='frames.js:version'], meta[property='frames.js:version']"
+  ).attr("content");
+
   return {
     farcaster,
     openframes: parseOpenFramesFrame(document, {
@@ -42,5 +48,6 @@ export function parseFramesWithReports({
       reporter: openFramesReporter,
       fallbackPostUrl,
     }),
+    framesVersion,
   };
 }


### PR DESCRIPTION
## Change Summary

This PR adds `frames.js:version` meta tag parsing to parsers and shows that in debugger.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
