### PR TITLE
feat: state signing

### DIFF
--- a/.changeset/eleven-moles-camp.md
+++ b/.changeset/eleven-moles-camp.md
@@ -1,0 +1,8 @@
+---
+"template-next-starter-with-examples": patch
+"frames.js": patch
+"docs": patch
+"create-frames": patch
+---
+
+feat: state signing secret option

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -18,9 +18,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  initialize:
+  build:
     timeout-minutes: 5
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [18, 20]
+    name: Build and Test on Node.js ${{ matrix.node }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -28,23 +32,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: 18
-          cache: "yarn"
-
-      - name: Install dependencies
-        run: yarn --frozen-lockfile
-
-  lint:
-    needs: [initialize]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
+          node-version: ${{ matrix.node }}
           cache: "yarn"
 
       - name: Install dependencies
@@ -56,50 +44,14 @@ jobs:
       - name: Lint
         run: yarn lint
 
-  typecheck:
-    needs: [initialize]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-          cache: "yarn"
-
-      - name: Install dependencies
-        run: yarn --frozen-lockfile
-
-      - name: Build
-        run: yarn build:ci
-
       - name: Typecheck
         run: yarn check:types
+
+      - name: Unit tests
+        run: yarn test:ci
 
       - name: Check package types
         run: yarn check:package-types
 
       - name: Lint packages
         run: yarn check:package-lint
-
-  test:
-    needs: [lint, typecheck]
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-          cache: "yarn"
-
-      - name: Install dependencies
-        run: yarn --frozen-lockfile
-
-      - name: Unit Tests
-        run: yarn test:ci

--- a/docs/pages/guides/state-management.mdx
+++ b/docs/pages/guides/state-management.mdx
@@ -70,3 +70,22 @@ const handler = frames(async ({ ctx }) => {
 export const GET = handler;
 export const POST = handler;
 ```
+
+## State protection using a signature
+
+In cases where frame state needs to be trusted, set the `stateSigningSecret` option in `createFrames` to sign and verify the state signature on each frame request to guarantee its integrity.
+
+```ts [frames.ts]
+import { createFrames } from "@framesjs/next";
+
+export type State = {
+  count: number;
+};
+
+export const frames = createFrames<State>({
+  initialState: {
+    count: 0,
+  },
+  stateSigningSecret: "my-secret-key", // [!code focus]
+});
+```

--- a/docs/pages/reference/core/createFrames.mdx
+++ b/docs/pages/reference/core/createFrames.mdx
@@ -49,6 +49,17 @@ An array of middleware functions that are called before the frame handler and al
 
 Each middleware should return a promise that resolves to the next middleware, or a [Web API `Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response), or a `FrameDefinition`.
 
+### `stateSigningSecret`
+
+- Type: `string`
+
+A secret key used to sign and verify the state in the frame message. If provided, state is automatically signed with this key and verified on each frame.
+
+- If the signature is present in state data:
+  - If the secret is not provided, the state will not be verified and used as is.
+  - If the secret is provided and signature does not match error is thrown.
+  - If the secret is provided and signature matches, the state will be used as is.
+
 #### Types
 
 For strong type support in the handler, the middleware should be typed as `FramesMiddleware<any, YourContextType>`.
@@ -167,7 +178,7 @@ const handleRequest = frames(async (ctx) => {
       aspectRatio: "1:1",
     },
     buttons: [<Button action="post">Refresh</Button>],
-    headers: { // [!code focus]
+    headers: {  // [!code focus]
       // Max cache age in seconds // [!code focus]
       "Cache-Control": "max-age=0", // [!code focus]
     }, // [!code focus]

--- a/packages/frames.js/src/core/createFrames.ts
+++ b/packages/frames.js/src/core/createFrames.ts
@@ -19,6 +19,7 @@ export function createFrames<
   initialState,
   middleware,
   baseUrl,
+  stateSigningSecret,
 }: FramesOptions<TState, TMiddlewares> = {}): FramesRequestHandlerFunction<
   TState,
   typeof coreMiddleware,
@@ -80,6 +81,7 @@ export function createFrames<
         request,
         url: new URL(request.url),
         baseUrl: resolveBaseUrl(request, url, basePath),
+        stateSigningSecret,
       };
 
       const result = await composedMiddleware(context);

--- a/packages/frames.js/src/core/types.ts
+++ b/packages/frames.js/src/core/types.ts
@@ -54,6 +54,7 @@ export type FramesContext<TState extends JsonValue | undefined = JsonValue> = {
    * Current request URL
    */
   url: URL;
+  stateSigningSecret?: string;
 };
 
 type AllowedFramesContextShape = Record<string, any>;
@@ -122,7 +123,10 @@ type FramesMiddlewareNextFunction<
 > = (context?: TReturnedContext) => FramesMiddlewareReturnType<TState>;
 
 export type FramesMiddlewareReturnType<TState extends JsonValue | undefined> =
-  Promise<FramesHandlerFunctionReturnType<TState> | Response>;
+  Promise<
+    | FramesHandlerFunctionReturnType<TState>
+    | FramesHandlerFunctionReturnType<string> // this handles serialized state
+  >;
 
 export type FramesMiddleware<
   TState extends JsonValue | undefined,
@@ -264,6 +268,11 @@ export type FramesOptions<
   middleware?: TFrameMiddleware extends undefined
     ? FramesMiddleware<any, any>[]
     : TFrameMiddleware;
+  /**
+   * If provided the state will be signed with this secret and validated on subsequent requests.
+   * If the signature is not valid, error is thrown.
+   */
+  stateSigningSecret?: string;
 };
 
 export type CreateFramesFunctionDefinition<

--- a/packages/frames.js/src/lib/crypto.ts
+++ b/packages/frames.js/src/lib/crypto.ts
@@ -1,0 +1,70 @@
+import { Buffer } from "node:buffer";
+import type { webcrypto } from "node:crypto";
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace -- we need this
+  namespace globalThis {
+    // eslint-disable-next-line no-var -- we need this
+    var EdgeRuntime: string | undefined;
+  }
+}
+
+async function getCryptoImplementation(): Promise<Crypto | webcrypto.Crypto> {
+  /**
+   * Vercel edge runtime by default provides crypto globally
+   * In node runtime we will import the crypto module even if it is globally available in node \>= 19
+   */
+  if (typeof EdgeRuntime !== "string") {
+    return import("node:crypto").then((mod) => mod.webcrypto);
+  }
+
+  return crypto;
+}
+
+async function createKey(secret: string): Promise<CryptoKey> {
+  const crypto = await getCryptoImplementation();
+
+  return crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"]
+  );
+}
+
+export async function createHMACSignature(
+  data: string,
+  secret: string
+): Promise<Buffer> {
+  const crypto = await getCryptoImplementation();
+  const secretKey = await createKey(secret);
+
+  return crypto.subtle
+    .sign(
+      {
+        name: "HMAC",
+      },
+      secretKey,
+      Buffer.from(data)
+    )
+    .then((arrayBuffer) => Buffer.from(new Uint8Array(arrayBuffer)));
+}
+
+export async function verifyHMACSignature(
+  data: string,
+  signature: Buffer,
+  secret: string
+): Promise<boolean> {
+  const crypto = await getCryptoImplementation();
+  const secretKey = await createKey(secret);
+
+  return crypto.subtle.verify(
+    {
+      name: "HMAC",
+    },
+    secretKey,
+    signature,
+    Buffer.from(data)
+  );
+}

--- a/packages/frames.js/src/middleware/images-worker/next/createImagesWorker.test.tsx
+++ b/packages/frames.js/src/middleware/images-worker/next/createImagesWorker.test.tsx
@@ -70,6 +70,36 @@ describe("createImagesWorker", () => {
     expect(response.status).toBe(401);
   });
 
+  it("should return an unauthorized response if the signature is missing", async () => {
+    const frame: FrameDefinition<undefined> = {
+      image: <div>Test</div>,
+    };
+
+    const mw = imagesWorkerMiddleware({
+      secret: "MY_TEST_SECRET",
+      imagesRoute: imagesRouteUrl,
+    });
+
+    const result = (await mw(context, () =>
+      Promise.resolve(frame)
+    )) as FrameDefinition<undefined>;
+
+    expect(typeof result.image).toBe("string");
+
+    const url = new URL(result.image as string);
+
+    url.searchParams.delete("signature");
+
+    const imagesRoute = createImagesWorker({
+      secret: "MY_TEST_SECRET",
+    });
+
+    const GET = imagesRoute();
+    const response = await GET(new Request(url));
+
+    expect(response.status).toBe(401);
+  });
+
   it("should render using a custom renderer if provided", async () => {
     const frame: FrameDefinition<undefined> = {
       image: <div>Test</div>,

--- a/packages/frames.js/src/middleware/stateMiddleware.test.ts
+++ b/packages/frames.js/src/middleware/stateMiddleware.test.ts
@@ -1,13 +1,25 @@
 /* eslint-disable no-console -- we expect the usage of console.log */
 import type { FramesContext } from "../core/types";
-import { stateMiddleware } from "./stateMiddleware";
+import { createHMACSignature } from "../lib/crypto";
+import { stateMiddleware, InvalidStateSignatureError } from "./stateMiddleware";
 
 describe("stateMiddleware", () => {
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    consoleWarnSpy = jest.spyOn(console, "warn");
+  });
+
+  beforeEach(() => {
+    consoleWarnSpy.mockReset();
+  });
+
   it("decodes JSON state from frame message and assigns it to ctx", async () => {
     const state = { foo: "bar" };
     const ctx = {
       message: { state: JSON.stringify(state) },
       initialState: {},
+      request: new Request("http://localhost", { method: "POST" }),
     };
     const mw = stateMiddleware();
     const next = jest.fn();
@@ -18,20 +30,22 @@ describe("stateMiddleware", () => {
   });
 
   it("uses initial state and warns user if JSON decode failed", async () => {
-    console.warn = jest.fn();
     const state = { foo: "bar" };
     const ctx = {
       message: { state },
       initialState: { initial: true },
+      request: new Request("http://localhost", { method: "POST" }),
     };
     const mw = stateMiddleware();
     const next = jest.fn();
 
-    expect(console.warn).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
 
     await mw(ctx as unknown as FramesContext, next);
 
-    expect(console.warn).toHaveBeenCalled();
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to parse state from frame message")
+    );
 
     expect(next).toHaveBeenCalledWith({ state: { initial: true } });
   });
@@ -39,6 +53,7 @@ describe("stateMiddleware", () => {
   it("uses initial state if there is no message", async () => {
     const ctx = {
       initialState: { initial: true },
+      request: new Request("http://localhost", { method: "POST" }),
     };
     const mw = stateMiddleware();
     const next = jest.fn();
@@ -53,12 +68,145 @@ describe("stateMiddleware", () => {
     const ctx = {
       message: { state: JSON.stringify(state) },
       initialState: {},
+      request: new Request("http://localhost", { method: "POST" }),
     };
     const mw = stateMiddleware();
     const next = jest.fn().mockReturnValue({ image: "/test" });
 
     const result = await mw(ctx as unknown as FramesContext, next);
 
-    expect(result).toEqual({ image: "/test", state });
+    expect(result).toEqual({ image: "/test", state: JSON.stringify(state) });
+  });
+
+  it("warns if state is returned but we are on initial frame", async () => {
+    const ctx = {
+      initialState: {},
+      request: new Request("http://localhost", { method: "GET" }),
+    };
+    const mw = stateMiddleware();
+    const next = jest
+      .fn()
+      .mockReturnValue({ image: "/test", state: { foo: "bar" } });
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+    await mw(ctx as unknown as FramesContext, next);
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("State is not supported on initial request")
+    );
+  });
+
+  describe("stateSigningSecret", () => {
+    it("signs state with provided secret", async () => {
+      const state = { foo: "bar" };
+      const ctx = {
+        initialState: {},
+        stateSigningSecret: "test",
+        request: new Request("http://localhost", { method: "POST" }),
+      };
+
+      const mw = stateMiddleware();
+      const next = jest.fn().mockResolvedValue({ image: "/test", state });
+
+      const result = await mw(ctx as unknown as FramesContext, next);
+      const signature = await createHMACSignature(
+        JSON.stringify(state),
+        "test"
+      ).then((buf) => buf.toString("hex"));
+
+      expect(result).toMatchObject({
+        image: "/test",
+        state: JSON.stringify({
+          data: state,
+          __sig: signature,
+        }),
+      });
+    });
+
+    it("throws an error if state signature verification failed", async () => {
+      const state = { foo: "bar" };
+      const signature = await createHMACSignature(
+        JSON.stringify(state),
+        "test"
+      ).then((buf) => buf.toString("hex"));
+      const ctx = {
+        message: {
+          state: JSON.stringify({
+            data: state,
+            __sig: signature,
+          }),
+        },
+        initialState: {},
+        stateSigningSecret: "test1",
+        request: new Request("http://localhost", { method: "POST" }),
+      };
+
+      const mw = stateMiddleware();
+      const next = jest.fn().mockResolvedValue({ image: "/test", state });
+
+      await expect(mw(ctx as unknown as FramesContext, next)).rejects.toThrow(
+        InvalidStateSignatureError
+      );
+    });
+
+    it("warns that state is signed and uses the state if secret is not provided", async () => {
+      const state = { foo: "bar" };
+      const signature = await createHMACSignature(
+        JSON.stringify(state),
+        "test"
+      ).then((buf) => buf.toString("hex"));
+      const ctx = {
+        message: {
+          state: JSON.stringify({
+            data: state,
+            __sig: signature,
+          }),
+        },
+        initialState: { initial: true },
+        request: new Request("http://localhost", { method: "POST" }),
+      };
+
+      const mw = stateMiddleware();
+      const next = jest.fn().mockResolvedValue({ image: "/test", state });
+
+      await mw(ctx as unknown as FramesContext, next);
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("State is signed but no secret is provided")
+      );
+
+      expect(next).toHaveBeenCalledWith({
+        state,
+      });
+    });
+
+    it("uses signed state if the secret matches", async () => {
+      const state = { foo: "bar" };
+      const signature = await createHMACSignature(
+        JSON.stringify(state),
+        "test"
+      ).then((buf) => buf.toString("hex"));
+      const ctx = {
+        message: {
+          state: JSON.stringify({
+            data: state,
+            __sig: signature,
+          }),
+        },
+        initialState: { initial: true },
+        stateSigningSecret: "test",
+        request: new Request("http://localhost", { method: "POST" }),
+      };
+
+      const mw = stateMiddleware();
+      const next = jest.fn().mockResolvedValue({ image: "/test", state });
+
+      await mw(ctx as unknown as FramesContext, next);
+
+      expect(next).toHaveBeenCalledWith({
+        state,
+      });
+    });
   });
 });

--- a/packages/frames.js/src/middleware/stateMiddleware.ts
+++ b/packages/frames.js/src/middleware/stateMiddleware.ts
@@ -1,5 +1,127 @@
-import type { FramesMiddleware, JsonValue } from "../core/types";
+import type { FramesContext, FramesMiddleware, JsonValue } from "../core/types";
 import { isFrameDefinition } from "../core/utils";
+import { createHMACSignature, verifyHMACSignature } from "../lib/crypto";
+
+export class InvalidStateSignatureError extends Error {}
+
+type SignedState<TState extends JsonValue | undefined> = {
+  data: Exclude<TState, undefined>;
+  __sig: string;
+};
+
+function isSignedState<TState extends JsonValue | undefined>(
+  data: TState | SignedState<TState>
+): data is SignedState<TState> {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "data" in data &&
+    "__sig" in data &&
+    typeof data.__sig === "string"
+  );
+}
+
+function parseState<TState extends JsonValue | undefined>(
+  state: string
+): TState | SignedState<TState> {
+  return JSON.parse(state) as TState | SignedState<TState>;
+}
+
+async function extractStateFromMessage<TState extends JsonValue | undefined>(
+  ctx: FramesContext<TState>
+): Promise<TState> {
+  let state: TState = ctx.initialState;
+
+  if (
+    "message" in ctx &&
+    typeof ctx.message === "object" &&
+    ctx.message &&
+    "state" in ctx.message
+  ) {
+    // since we are stringifyng state to JSON in renderResponse middleware, we need to parse decode JSON here
+    // so it is easy to use in middleware chain and frames handler
+    if (ctx.message.state) {
+      try {
+        if (typeof ctx.message.state !== "string") {
+          throw new Error("State is not a string");
+        }
+
+        const parsedState = parseState<TState>(ctx.message.state);
+
+        if (isSignedState<TState>(parsedState)) {
+          // if state is signed verify it with secret, otherwise treat it as valid automatically (backward compatibility)
+          if (ctx.stateSigningSecret) {
+            const isValidSignature = await verifyHMACSignature(
+              JSON.stringify(parsedState.data),
+              Buffer.from(parsedState.__sig, "hex"),
+              ctx.stateSigningSecret
+            );
+
+            if (!isValidSignature) {
+              throw new InvalidStateSignatureError(
+                "State signature verification failed"
+              );
+            } else {
+              state = parsedState.data;
+            }
+          } else {
+            // eslint-disable-next-line no-console -- provide feedback
+            console.warn(
+              "State is signed but no secret is provided, ignoring signature verification"
+            );
+            state = parsedState.data;
+          }
+        } else {
+          state = parsedState;
+        }
+      } catch (e) {
+        if (e instanceof InvalidStateSignatureError) {
+          throw e;
+        }
+
+        // eslint-disable-next-line no-console -- provide feedback
+        console.warn(
+          "Failed to parse state from frame message, are you sure that the state was constructed by frames.js?"
+        );
+        state = ctx.initialState;
+      }
+    }
+  }
+
+  return state;
+}
+
+async function serializeState<TState extends JsonValue | undefined>(
+  state: TState,
+  ctx: FramesContext<TState>
+): Promise<string | undefined> {
+  if (state === undefined) {
+    return undefined;
+  }
+
+  if (ctx.request.method === "POST") {
+    if (ctx.stateSigningSecret) {
+      const signature = await createHMACSignature(
+        JSON.stringify(state),
+        ctx.stateSigningSecret
+      ).then((buf) => buf.toString("hex"));
+
+      return JSON.stringify({
+        data: state as Exclude<TState, undefined>,
+        __sig: signature,
+      } satisfies SignedState<TState>);
+    }
+
+    return JSON.stringify(state);
+  }
+
+  // eslint-disable-next-line no-console -- provide feedback to the user
+  console.warn(
+    "State is not supported on initial request (the one initialized when Frames are rendered for first time, that uses GET request) and will be ignored"
+  );
+
+  return undefined;
+}
 
 type StateMiddlewareContext<TState extends JsonValue | undefined> = {
   /**
@@ -11,52 +133,29 @@ type StateMiddlewareContext<TState extends JsonValue | undefined> = {
 };
 
 /**
- * This middleware infers a state from ctx.message or uses ctx.initialState if message is not present or does not contain a state.
+ * This middleware handles state extraction from frame message and state serialization on response.
+ *
+ * If the message does not contain a state, the middleware uses `initialState` value passed to `createFrames` function.
+ * If state is signed and signature is not valid, error is thrown.
+ *
  * This middleware is internal only and must run after globalMiddleware and before perRouteMiddleware. So the message is available.
  */
 export function stateMiddleware<
   TState extends JsonValue | undefined,
 >(): FramesMiddleware<TState, StateMiddlewareContext<TState>> {
   return async (ctx, next) => {
-    if (
-      "message" in ctx &&
-      typeof ctx.message === "object" &&
-      ctx.message &&
-      "state" in ctx.message
-    ) {
-      let state: TState = ctx.initialState;
+    const stateFromMessage: TState = await extractStateFromMessage<TState>(ctx);
 
-      // since we are stringifyng state to JSON in renderResponse middleware, we need to parse decode JSON here
-      // so it is easy to use in middleware chain and frames handler
-      if (ctx.message.state) {
-        try {
-          if (typeof ctx.message.state !== "string") {
-            throw new Error("State is not a string");
-          }
+    const nextResult = await next({
+      state: stateFromMessage,
+    });
 
-          state = JSON.parse(ctx.message.state) as TState;
-        } catch (e) {
-          // eslint-disable-next-line no-console -- provide feedback
-          console.warn(
-            "Failed to parse state from frame message, are you sure that the state was constructed by frames.js?"
-          );
-          state = ctx.initialState;
-        }
-      }
-
-      const nextResult = await next({
-        state,
-      });
-
-      if (isFrameDefinition(nextResult)) {
-        // Include previous state if it is not present in the result
-        return {
-          state,
-          ...nextResult,
-        };
-      }
-
-      return nextResult;
+    if (isFrameDefinition(nextResult)) {
+      // Include previous state if it is not present in the result
+      return {
+        ...nextResult,
+        state: await serializeState(nextResult.state ?? stateFromMessage, ctx),
+      };
     }
 
     return next({

--- a/packages/frames.js/tsup.config.ts
+++ b/packages/frames.js/tsup.config.ts
@@ -6,7 +6,7 @@ import glob from "fast-glob";
 export default defineConfig({
   // this is necessary for cloudfare workers adapter to be able to import
   // buffer from cloudflare compatiblity layer
-  external: ["node:buffer"],
+  external: ["node:buffer", "node:crypto"],
   dts: true,
   format: ["cjs", "esm"],
   clean: true,

--- a/templates/next-starter-with-examples/app/examples/new-api-state-signing/frames/frames.ts
+++ b/templates/next-starter-with-examples/app/examples/new-api-state-signing/frames/frames.ts
@@ -1,0 +1,15 @@
+import { createFrames } from "frames.js/next";
+import { appURL } from "../../../utils";
+
+type State = {
+  count: number;
+};
+
+export const frames = createFrames<State>({
+  initialState: {
+    count: 0,
+  },
+  basePath: "/examples/new-api-state-signing/frames",
+  baseUrl: appURL(),
+  stateSigningSecret: "my-secret-key",
+});

--- a/templates/next-starter-with-examples/app/examples/new-api-state-signing/frames/route.tsx
+++ b/templates/next-starter-with-examples/app/examples/new-api-state-signing/frames/route.tsx
@@ -1,0 +1,32 @@
+/* eslint-disable react/jsx-key */
+import { Button } from "frames.js/next";
+import { frames } from "./frames";
+
+const handler = frames((ctx) => {
+  let state = ctx.state;
+
+  switch (ctx.searchParams.action) {
+    case "increment":
+      state = { ...state, count: state.count + 1 };
+      break;
+    case "decrement":
+      state = { ...state, count: state.count - 1 };
+      break;
+  }
+
+  return {
+    image: <div tw="flex">Count: {state.count}</div>,
+    buttons: [
+      <Button action="post" target={{ query: { action: "increment" } }}>
+        Increment
+      </Button>,
+      <Button action="post" target={{ query: { action: "decrement" } }}>
+        Decrement
+      </Button>,
+    ],
+    state,
+  };
+});
+
+export const GET = handler;
+export const POST = handler;

--- a/templates/next-starter-with-examples/app/examples/new-api-state-signing/page.tsx
+++ b/templates/next-starter-with-examples/app/examples/new-api-state-signing/page.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { currentURL, appURL } from "../../utils";
+import { createDebugUrl } from "../../debug";
+import type { Metadata } from "next";
+import { fetchMetadata } from "frames.js/next";
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: "New api example with state signing",
+    description: "This is a new api example",
+    other: {
+      ...(await fetchMetadata(
+        new URL("/examples/new-api-state-signing/frames", appURL())
+      )),
+    },
+  };
+}
+
+export default async function Home() {
+  const url = currentURL("/examples/new-api-state-signing");
+
+  return (
+    <div>
+      State signing
+      <Link href={createDebugUrl(url)} className="underline">
+        Debug
+      </Link>
+    </div>
+  );
+}

--- a/templates/next-starter-with-examples/app/examples/page.tsx
+++ b/templates/next-starter-with-examples/app/examples/page.tsx
@@ -54,6 +54,11 @@ export default function ExamplesIndexPage() {
           </Link>
         </li>
         <li>
+          <Link className="underline" href="/examples/new-api-state-signing">
+            State Signing
+          </Link>
+        </li>
+        <li>
           <Link
             className="underline"
             href="/examples/new-api-state-via-query-params"


### PR DESCRIPTION
## Change Summary

This PR adds `stateSigningSecret` option to `createFrames` that can be used to sign `state`.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
