### PR TITLE
Update display-frames.mdx to better explain onSignerlessFramePress

### DIFF
--- a/docs/pages/guides/apps/display-frames.mdx
+++ b/docs/pages/guides/apps/display-frames.mdx
@@ -68,10 +68,11 @@ export default function Page() {
     frameContext: fallbackFrameContext,
     // map to your identity if you have one
     signerState: {
-      hasSigner: true,
+      hasSigner: farcasterSigner !== undefined,
       signer: farcasterSigner,
       onSignerlessFramePress: () => {
-        // Implement me
+        // Only run if `hasSigner` is set to `false`
+        // This is a good place to throw an error or prompt the user to login
         alert("A frame button was pressed without a signer. Perhaps you want to prompt a login");
       },
       signFrameAction: signFrameAction,


### PR DESCRIPTION
## Change Summary

Currently, there is nothing that notes that `hasSigner` will stop the running of `onSignerlessFramePress`. It is misleading to have the documentation show `hasSigner =  true` and show `onSignerlessFramePress`, when one of these overrides the other

The following changes to the guide better explain this intereaction

## Merge Checklist

- [x] PR has a [Changeset](CONTRIBUTING.md) -- N/A
- [x] PR includes documentation if necessary -- Done, all documentation changes
- [x] PR updates the boilerplates if necessary -- N/A
