### PR TITLE
fix(create-frames): properly parse package version for CLI command

### DIFF
--- a/.changeset/hip-singers-mate.md
+++ b/.changeset/hip-singers-mate.md
@@ -1,0 +1,5 @@
+---
+"create-frames": patch
+---
+
+fix(create-frames): properly parse package version for CLI command

--- a/packages/create-frames/bin.js
+++ b/packages/create-frames/bin.js
@@ -1,8 +1,16 @@
 #!/usr/bin/env node
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
+import { dirname, resolve } from "node:path";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { getTemplates } from "./utils/getTemplates.js";
 import { create } from "./create.js";
+
+const packageJsonFilePath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "./package.json"
+);
 
 // use only default command
 yargs(hideBin(process.argv))
@@ -27,4 +35,5 @@ yargs(hideBin(process.argv))
       create(args);
     }
   )
+  .version(JSON.parse(readFileSync(packageJsonFilePath)).version)
   .parse();


### PR DESCRIPTION
## Change Summary

This PR fixes version reported when using `create-frames --version`.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
