### PR TITLE
fix: $ escaping in docs

### DIFF
--- a/.changeset/selfish-bees-sparkle.md
+++ b/.changeset/selfish-bees-sparkle.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+fix: $ escaping in docs

--- a/docs/pages/guides/create-frame.mdx
+++ b/docs/pages/guides/create-frame.mdx
@@ -82,7 +82,7 @@ export async function generateMetadata() {
       new URL(
         "/frames",
         process.env.VERCEL_URL
-          ? `https://${process.env.VERCEL_URL}`
+          ? `https://$${process.env.VERCEL_URL}`
           : "http://localhost:3000"
       )
     ),

--- a/docs/pages/guides/multiple-frames.mdx
+++ b/docs/pages/guides/multiple-frames.mdx
@@ -75,7 +75,7 @@ export async function generateMetadata() {
       new URL(
         "/frames",
         process.env.VERCEL_URL
-          ? `https://${process.env.VERCEL_URL}`
+          ? `https://$${process.env.VERCEL_URL}`
           : "http://localhost:3000"
       )
     ),

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -122,7 +122,7 @@ export async function generateMetadata() {
         new URL(
           "/frames",
           process.env.VERCEL_URL
-            ? `https://${process.env.VERCEL_URL}`
+            ? `https://$${process.env.VERCEL_URL}`
             : "http://localhost:3000"
         )
       )),

--- a/docs/pages/troubleshooting.mdx
+++ b/docs/pages/troubleshooting.mdx
@@ -44,7 +44,7 @@ export async function generateMetadata() {
     new URL(
       "/frames",
       process.env.VERCEL_URL
-        ? `https://${process.env.VERCEL_URL}`
+        ? `https://$${process.env.VERCEL_URL}`
         : "http://localhost:3000"
     )
   );


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->

Workaround for `$` escaping issue in docs. Open issue in https://github.com/wevm/vocs/issues/164

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
