### PR TITLE
fix: upgrade typescript to get rid of inference errors

### DIFF
--- a/.changeset/famous-fans-poke.md
+++ b/.changeset/famous-fans-poke.md
@@ -1,0 +1,12 @@
+---
+"template-next-starter-with-examples": patch
+"template-next-utils-starter": patch
+"template-cloudflare-worker": patch
+"template-express": patch
+"template-remix": patch
+"template-hono": patch
+"template-next": patch
+"create-frames": patch
+---
+
+fix(create-frames): upgrade typescript and remove declaration options from tsconfig

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -70,7 +70,7 @@
     "tailwind-merge": "^2.2.1",
     "tailwindcss": "^3.3.0",
     "tailwindcss-animate": "^1.0.7",
-    "typescript": "^5.3.3",
+    "typescript": "^5.4.5",
     "viem": "^2.9.28",
     "wagmi": "^2.7.0"
   },

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -14,6 +14,6 @@
     "eslint-plugin-only-warn": "^1.1.0",
     "@typescript-eslint/parser": "^6.17.0",
     "@typescript-eslint/eslint-plugin": "^6.17.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.4.5"
   }
 }

--- a/packages/frames.js/package.json
+++ b/packages/frames.js/package.json
@@ -296,7 +296,7 @@
     "hono": "^4.1.3",
     "supertest": "^6.3.4",
     "tsup": "^8.0.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.4.5"
   },
   "license": "MIT",
   "peerDependencies": {

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -73,7 +73,7 @@
   "devDependencies": {
     "@remix-run/node": "^2.8.1",
     "tsup": "^8.0.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.4.5"
   },
   "license": "MIT",
   "peerDependencies": {

--- a/templates/cloudflare-worker/package.json
+++ b/templates/cloudflare-worker/package.json
@@ -16,7 +16,7 @@
     "@types/react": "^18.2.45",
     "concurrently": "^8.2.2",
     "cross-env": "^7.0.3",
-    "typescript": "^5.1.6",
+    "typescript": "^5.4.5",
     "vitest": "1.3.0",
     "wrangler": "^3.39.0"
   },

--- a/templates/express/package.json
+++ b/templates/express/package.json
@@ -18,7 +18,7 @@
     "@vitejs/plugin-react": "^4.2.1",
     "concurrently": "^8.2.2",
     "cross-env": "^7.0.3",
-    "typescript": "^5.1.6",
+    "typescript": "^5.4.5",
     "vite": "^5.1.0",
     "vite-tsconfig-paths": "^4.2.1"
   },

--- a/templates/hono/package.json
+++ b/templates/hono/package.json
@@ -17,7 +17,7 @@
     "@vitejs/plugin-react": "^4.2.1",
     "concurrently": "^8.2.2",
     "cross-env": "^7.0.3",
-    "typescript": "^5.1.6",
+    "typescript": "^5.4.5",
     "vite": "^5.1.0",
     "vite-tsconfig-paths": "^4.2.1"
   },

--- a/templates/next-starter-with-examples/package.json
+++ b/templates/next-starter-with-examples/package.json
@@ -35,6 +35,6 @@
     "eslint-config-next": "^14.1.0",
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.4.5"
   }
 }

--- a/templates/next-starter-with-examples/tsconfig.json
+++ b/templates/next-starter-with-examples/tsconfig.json
@@ -13,25 +13,25 @@
     "noUncheckedIndexedAccess": true,
     "plugins": [
       {
-        "name": "next",
-      },
+        "name": "next"
+      }
     ],
     "paths": {
-      "@/*": ["./@/*"],
+      "@/*": ["./@/*"]
     },
     "jsx": "preserve",
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
     "target": "ES2022",
-    "allowJs": true,
+    "allowJs": true
   },
   "include": [
     "next-env.d.ts",
     "next.config.js",
     "**/*.ts",
     "**/*.tsx",
-    ".next/types/**/*.ts",
+    ".next/types/**/*.ts"
   ],
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules"]
 }

--- a/templates/next-utils-starter/package.json
+++ b/templates/next-utils-starter/package.json
@@ -26,7 +26,7 @@
     "concurrently": "^8.2.2",
     "dotenv": "^16.4.5",
     "eslint": "^8.56.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.4.5"
   },
   "engines": {
     "node": ">=18.17.0"

--- a/templates/next-utils-starter/tsconfig.json
+++ b/templates/next-utils-starter/tsconfig.json
@@ -2,8 +2,6 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Default",
   "compilerOptions": {
-    "declaration": true,
-    "declarationMap": true,
     "esModuleInterop": true,
     "incremental": false,
     "isolatedModules": true,
@@ -15,25 +13,25 @@
     "noUncheckedIndexedAccess": true,
     "plugins": [
       {
-        "name": "next",
-      },
+        "name": "next"
+      }
     ],
     "paths": {
-      "@/*": ["./@/*"],
+      "@/*": ["./@/*"]
     },
     "jsx": "preserve",
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
     "target": "ES2022",
-    "allowJs": true,
+    "allowJs": true
   },
   "include": [
     "next-env.d.ts",
     "next.config.js",
     "**/*.ts",
     "**/*.tsx",
-    ".next/types/**/*.ts",
+    ".next/types/**/*.ts"
   ],
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules"]
 }

--- a/templates/next/package.json
+++ b/templates/next/package.json
@@ -15,7 +15,7 @@
     "@types/react-dom": "^18.2.0",
     "@frames.js/debugger": "^0.2.8",
     "concurrently": "^8.2.2",
-    "typescript": "^5.3.3"
+    "typescript": "^5.4.5"
   },
   "scripts": {
     "dev": "concurrently \"next dev\" \"frames --url http://localhost:3000\"",

--- a/templates/remix/package.json
+++ b/templates/remix/package.json
@@ -23,7 +23,7 @@
     "@typescript-eslint/eslint-plugin": "^6.7.4",
     "@typescript-eslint/parser": "^6.7.4",
     "concurrently": "^8.2.2",
-    "typescript": "^5.1.6",
+    "typescript": "^5.4.5",
     "vite": "^5.1.0",
     "vite-tsconfig-paths": "^4.2.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14572,10 +14572,10 @@ typescript@5.3.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
   integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
 
-typescript@^5.1.6, typescript@^5.3.3:
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.3.tgz#5c6fedd4c87bee01cd7a528a30145521f8e0feff"
-  integrity sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==
+typescript@^5.4.5:
+  version "5.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
+  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
 
 ua-parser-js@^1.0.36, ua-parser-js@^1.0.37:
   version "1.0.37"


### PR DESCRIPTION
## Change Summary

This PR upgrades typescript in templates to get rid of potential type inferrence errors `ts2742`.

Also it removes `declaration` and `declarationMap` properties from `tsconfig.json` which causes the error in combination with `typescript@5.3.3` (see #352).

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
