### PR TITLE
fix(frames.js): correctly generate button target url if pathname is missing

### DIFF
--- a/.changeset/dry-cameras-cover.md
+++ b/.changeset/dry-cameras-cover.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix(frames.js): correctly generate button target url if pathname is not set

--- a/packages/frames.js/src/core/utils.test.ts
+++ b/packages/frames.js/src/core/utils.test.ts
@@ -2,7 +2,46 @@ import {
   generatePostButtonTargetURL,
   parseButtonInformationFromTargetURL,
   resolveBaseUrl,
+  generateTargetURL,
 } from "./utils";
+
+describe("generateTargetURL", () => {
+  it("generates a correct URL with baseUrl if pathname is missing", () => {
+    const baseUrl = new URL("http://test.com/frames");
+    const target = { query: { test: "test" } };
+
+    expect(generateTargetURL({ baseUrl, target }).toString()).toBe(
+      "http://test.com/frames?test=test"
+    );
+  });
+
+  it("generates a correct URL if pathname is set", () => {
+    const baseUrl = new URL("http://test.com/frames");
+    const target = { pathname: "/test", query: { test: "test" } };
+
+    expect(generateTargetURL({ baseUrl, target }).toString()).toBe(
+      "http://test.com/frames/test?test=test"
+    );
+  });
+
+  it("generates a correct URL if target is an absolute URL", () => {
+    const baseUrl = new URL("http://test.com");
+    const target = "http://test.com/test";
+
+    expect(generateTargetURL({ baseUrl, target }).toString()).toBe(
+      "http://test.com/test"
+    );
+  });
+
+  it("generates a correct URL if target is an absolute URL with query params", () => {
+    const baseUrl = new URL("http://test.com");
+    const target = "http://test.com/test?test=test";
+
+    expect(generateTargetURL({ baseUrl, target }).toString()).toBe(
+      "http://test.com/test?test=test"
+    );
+  });
+});
 
 describe("resolveBaseUrl", () => {
   it("uses URL from request if no baseUrl is provided", () => {

--- a/packages/frames.js/src/core/utils.ts
+++ b/packages/frames.js/src/core/utils.ts
@@ -10,7 +10,7 @@ const buttonActionToCode = {
 const BUTTON_INFORMATION_SEARCH_PARAM_NAME = "__bi";
 
 export function joinPaths(pathA: string, pathB: string): string {
-  return pathB === "/"
+  return pathB === "/" || pathB === ""
     ? pathA
     : [pathA, pathB].join("/").replace(/\/{2,}/g, "/");
 }


### PR DESCRIPTION
## Change Summary

This PR fixes how button target url is generated if `pathname` is no provided. Closes #377.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
