### PR TITLE
feat(render): export next route handlers in isolated file

### DIFF
--- a/.changeset/five-pants-speak.md
+++ b/.changeset/five-pants-speak.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/render": patch
+---
+
+feat(render): export next route handlers in isolated file

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -45,6 +45,16 @@
         "default": "./dist/next/index.cjs"
       }
     },
+    "./next/route-handlers": {
+      "import": {
+        "types": "./dist/next/route-handlers.d.ts",
+        "default": "./dist/next/route-handlers.js"
+      },
+      "require": {
+        "types": "./dist/next/route-handlers.d.cts",
+        "default": "./dist/next/route-handlers.cjs"
+      }
+    },
     "./farcaster": {
       "import": {
         "types": "./dist/farcaster/index.d.ts",

--- a/packages/render/src/next/GET.tsx
+++ b/packages/render/src/next/GET.tsx
@@ -2,11 +2,14 @@ import { getFrame } from "frames.js";
 import type { NextRequest } from "next/server";
 import { isSpecificationValid } from "./validators";
 
-
 /** Proxies fetching a frame through a backend to avoid CORS issues and preserve user IP privacy */
-export async function GET(request: NextRequest): Promise<Response> {
-  const url = request.nextUrl.searchParams.get("url");
-  const specification = request.nextUrl.searchParams.get('specification') ?? 'farcaster';
+export async function GET(request: Request | NextRequest): Promise<Response> {
+  const searchParams =
+    "nextUrl" in request
+      ? request.nextUrl.searchParams
+      : new URL(request.url).searchParams;
+  const url = searchParams.get("url");
+  const specification = searchParams.get("specification") ?? "farcaster";
 
   if (!url) {
     return Response.json({ message: "Invalid URL" }, { status: 400 });

--- a/packages/render/src/next/POST.tsx
+++ b/packages/render/src/next/POST.tsx
@@ -4,15 +4,14 @@ import type { NextRequest } from "next/server";
 import { isSpecificationValid } from "./validators";
 
 /** Proxies frame actions to avoid CORS issues and preserve user IP privacy */
-export async function POST(req: NextRequest): Promise<Response> {
+export async function POST(req: Request | NextRequest): Promise<Response> {
+  const searchParams =
+    "nextUrl" in req ? req.nextUrl.searchParams : new URL(req.url).searchParams;
   const body = (await req.json()) as FrameActionPayload;
-  const isPostRedirect =
-    req.nextUrl.searchParams.get("postType") === "post_redirect";
-  const isTransactionRequest =
-    req.nextUrl.searchParams.get("postType") === "tx";
-  const postUrl = req.nextUrl.searchParams.get("postUrl");
-  const specification =
-    req.nextUrl.searchParams.get("specification") ?? "farcaster";
+  const isPostRedirect = searchParams.get("postType") === "post_redirect";
+  const isTransactionRequest = searchParams.get("postType") === "tx";
+  const postUrl = searchParams.get("postUrl");
+  const specification = searchParams.get("specification") ?? "farcaster";
 
   if (!postUrl) {
     return Response.error();

--- a/packages/render/src/next/route-handlers.ts
+++ b/packages/render/src/next/route-handlers.ts
@@ -1,0 +1,2 @@
+export { GET } from "./GET";
+export { POST } from "./POST";


### PR DESCRIPTION
## Change Summary

This PR exportes next router handlers from `@frames.js/render` in isolated file as well. This is useful for only server side reexport where we don't need `react` or `next` at all.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
