### PR TITLE
feat: warn if og tag is missing

### DIFF
--- a/.changeset/clever-bikes-pump.md
+++ b/.changeset/clever-bikes-pump.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+feat: warn if og tag is missing instead of error

--- a/packages/frames.js/src/frame-parsers/farcaster.test.ts
+++ b/packages/frames.js/src/frame-parsers/farcaster.test.ts
@@ -107,7 +107,7 @@ describe("farcaster frame parser", () => {
   });
 
   describe("og:image", () => {
-    it("fails if og image is missing", () => {
+    it("warns if og image is missing", () => {
       const $ = load(`
     <meta name="fc:frame" content="vNext"/>
     <meta name="fc:frame:image" content="http://example.com/image.png"/>
@@ -115,12 +115,12 @@ describe("farcaster frame parser", () => {
     `);
 
       expect(parseFarcasterFrame($, { reporter, fallbackPostUrl })).toEqual({
-        status: "failure",
+        status: "success",
         reports: {
           "og:image": [
             {
-              level: "error",
-              message: 'Missing required meta tag "og:image"',
+              level: "warning",
+              message: 'Missing meta tag "og:image"',
               source: "farcaster",
             },
           ],

--- a/packages/frames.js/src/frame-parsers/farcaster.ts
+++ b/packages/frames.js/src/frame-parsers/farcaster.ts
@@ -57,7 +57,7 @@ export function parseFarcasterFrame(
   }
 
   if (!parsedFrame.ogImage) {
-    reporter.error("og:image", 'Missing required meta tag "og:image"');
+    reporter.warn("og:image", 'Missing meta tag "og:image"');
   } else {
     frame.ogImage = validate(
       reporter,

--- a/packages/frames.js/src/frame-parsers/open-frames.test.ts
+++ b/packages/frames.js/src/frame-parsers/open-frames.test.ts
@@ -230,7 +230,7 @@ describe("open frames frame parser", () => {
   });
 
   describe("og:image", () => {
-    it("fails if og image is missing", () => {
+    it("warns if og image is missing", () => {
       const $ = load(`
     <meta name="of:version" content="vNext"/>
     <meta name="of:accepts:some_protocol" content="vNext"/> 
@@ -245,12 +245,12 @@ describe("open frames frame parser", () => {
           reporter,
         })
       ).toEqual({
-        status: "failure",
+        status: "success",
         reports: {
           "og:image": [
             {
-              level: "error",
-              message: 'Missing required meta tag "og:image"',
+              level: "warning",
+              message: 'Missing meta tag "og:image"',
               source: "openframes",
             },
           ],

--- a/packages/frames.js/src/frame-parsers/open-frames.ts
+++ b/packages/frames.js/src/frame-parsers/open-frames.ts
@@ -101,7 +101,7 @@ export function parseOpenFramesFrame(
   }
 
   if (!parsedFrame.ogImage) {
-    reporter.error("og:image", 'Missing required meta tag "og:image"');
+    reporter.warn("og:image", 'Missing meta tag "og:image"');
   } else {
     frame.ogImage = validate(
       reporter,

--- a/packages/frames.js/src/getFrame.test.ts
+++ b/packages/frames.js/src/getFrame.test.ts
@@ -255,4 +255,65 @@ describe("getFrame", () => {
 
     expect(result.framesVersion).toEqual("1.0.0");
   });
+
+  it("should parse a frame that does not have an og:image tag", () => {
+    const htmlString = `
+    <meta name="fc:frame" content="vNext" />
+    <meta name="fc:frame:image" content="http://example.com/image.png" />
+    <meta name="fc:frame:button:1" content="Green" />
+    <meta name="fc:frame:button:2" content="Purple" />
+    <meta name="fc:frame:button:3" content="Red" />
+    <meta name="fc:frame:button:4" content="Blue" />
+    <meta name="fc:frame:post_url" content="https://example.com" />
+    <meta name="fc:frame:input:text" content="Enter a message" />
+    <title>test</title>
+  `;
+
+    const parseResult = getFrame({
+      htmlString,
+      url: "https://example.com",
+    });
+
+    expect(parseResult).toEqual({
+      status: "success",
+      frame: {
+        version: "vNext",
+        image: "http://example.com/image.png",
+        ogImage: undefined,
+        buttons: [
+          {
+            label: "Green",
+            action: "post",
+            target: undefined,
+          },
+          {
+            label: "Purple",
+            action: "post",
+            target: undefined,
+          },
+          {
+            label: "Red",
+            action: "post",
+            target: undefined,
+          },
+          {
+            label: "Blue",
+            action: "post",
+            target: undefined,
+          },
+        ],
+        postUrl: "https://example.com/",
+        inputText: "Enter a message",
+      },
+      reports: {
+        "og:image": [
+          {
+            level: "warning",
+            message: 'Missing meta tag "og:image"',
+            source: "farcaster",
+          },
+        ],
+      },
+    });
+  });
 });


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Replaces warning and parsing failure when `og:image` fallback is missing with warning

Fixes #387 

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
