### PR TITLE
fix: properly format url based on VERCEL_URL

### DIFF
--- a/.changeset/healthy-dingos-crash.md
+++ b/.changeset/healthy-dingos-crash.md
@@ -1,0 +1,9 @@
+---
+"template-next-starter-with-examples": patch
+"frames.js": patch
+"template-next": patch
+"docs": patch
+"create-frames": patch
+---
+
+fix: properly format url based on VERCEL_URL

--- a/docs/pages/reference/core/next-pages-router/index.mdx
+++ b/docs/pages/reference/core/next-pages-router/index.mdx
@@ -41,7 +41,9 @@ export const getServerSideProps = async function getServerSideProps() {
       metadata: await fetchMetadata(
         new URL(
           "/api/frames",
-          process.env.VERCEL_URL || "http://localhost:3000"
+          process.env.VERCEL_URL
+            ? `https://$${process.env.VERCEL_URL}`
+            : "http://localhost:3000"
         )
       ),
     },

--- a/docs/pages/reference/core/next/index.mdx
+++ b/docs/pages/reference/core/next/index.mdx
@@ -38,9 +38,14 @@ export async function generateMetadata() {
       // ...
       ...(await fetchMetadata(
         // provide full URL to your /frames endpoint
-        new URL("/frames", process.env.VERCEL_URL || "http://localhost:3000")
+        new URL(
+          "/frames",
+          process.env.VERCEL_URL
+            ? `https://$${process.env.VERCEL_URL}`
+            : "http://localhost:3000"
+        )
       )),
-    }
+    },
   };
 }
 

--- a/packages/frames.js/src/next/fetchMetadata.ts
+++ b/packages/frames.js/src/next/fetchMetadata.ts
@@ -19,7 +19,7 @@ import { FRAMES_META_TAGS_HEADER } from "../core/constants";
  *     ...(await fetchMetadata(
  *       new URL(
  *        "/examples/new-api/frames",
- *        process.env.VERCEL_URL || "http://localhost:3000"
+ *        process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000"
  *       )),
  *     ),
  *   },
@@ -36,7 +36,7 @@ import { FRAMES_META_TAGS_HEADER } from "../core/constants";
  *  return {
  *    props: {
  *      metadata: await fetchMetadata(
- *        new URL("/api", process.env.VERCEL_URL || "http://localhost:3000")
+ *        new URL("/api", process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000")
  *      ),
  *    },
  *  };

--- a/packages/frames.js/src/next/pages-router/client.tsx
+++ b/packages/frames.js/src/next/pages-router/client.tsx
@@ -18,7 +18,7 @@ export { fetchMetadata } from "../fetchMetadata";
  *  return {
  *   props: {
  *    metadata: await fetchMetadata(
- *     new URL("/api", process.env.VERCEL_URL || "http://localhost:3000")
+ *     new URL("/api", process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000")
  *    ),
  *  },
  * };

--- a/templates/next-starter-with-examples/pages/examples/pages-router/index.tsx
+++ b/templates/next-starter-with-examples/pages/examples/pages-router/index.tsx
@@ -10,7 +10,7 @@ export const getServerSideProps = async function getServerSideProps() {
       metadata: await fetchMetadata(
         new URL(
           "/api/frames",
-          process.env.VERCEL_URL || "http://localhost:3000"
+          process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000"
         )
       ),
     },

--- a/templates/next/app/page.tsx
+++ b/templates/next/app/page.tsx
@@ -6,7 +6,7 @@ export async function generateMetadata(): Promise<Metadata> {
     title: "Frames Next.js Example",
     other: {
       ...(await fetchMetadata(
-        new URL("/frames", process.env.VERCEL_URL || "http://localhost:3000")
+        new URL("/frames", process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000")
       )),
     },
   };


### PR DESCRIPTION
## Change Summary

This PR fixes examples and docs where `process.env.VERCEL` is directly used to create an URL.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
