### PR TITLE
fix: when no debugger url specified

### DIFF
--- a/templates/next-starter-with-examples/.env.sample
+++ b/templates/next-starter-with-examples/.env.sample
@@ -1,17 +1,15 @@
-# Example: FARCASTER_DEVELOPER_MNEMONIC="candy gibraltar foxtrot kilo barnacles foxes ..."
-# (OPTIONAL) Needed for the debugger to create a real Farcaster signer. Get this by exporting your seed phrase from the Warpcast app. Don't share that seed phrase with anyone.
-FARCASTER_DEVELOPER_MNEMONIC=
-# (OPTIONAL) Only needed for the debugger to create a real Farcaster signer. Get this by visiting your Warpccast profile, pressing the kebab (three dots) menu and then "About" and then your fid should be there.
-# Example: FARCASTER_DEVELOPER_FID=1214
-FARCASTER_DEVELOPER_FID=
-# (OPTIONAL) Hub URL to use for the debugger. If not set, the debugger will use the default hub URL.
-DEBUG_HUB_HTTP_URL=
+# Used by new API examples
+APP_URL="http://localhost:3000"
 
+# Used by deprecated examples
 NEXT_PUBLIC_HOST="http://localhost:3000"
 
-# OPTIONAL EXAMPLE KEYS
-# Optional, if you use this example
-KV_REST_API_URL=""
-KV_REST_API_TOKEN=""
-# Optional
-DEBUGGER_URL=""
+# Optional - Hub URL to use for the debugger. If not set, the debugger will use the default hub URL.
+DEBUG_HUB_HTTP_URL=
+
+# Optional - Slow request example
+KV_REST_API_URL=
+KV_REST_API_TOKEN=
+
+# Optional - debugging URL for the examples index page
+DEBUGGER_URL=

--- a/templates/next-starter-with-examples/app/debug.ts
+++ b/templates/next-starter-with-examples/app/debug.ts
@@ -1,5 +1,5 @@
 const DEFAULT_DEBUGGER_URL =
-  process.env.DEBUGGER_URL ?? "http://localhost:3010/";
+  process.env.DEBUGGER_URL || "http://localhost:3010/";
 
 export const DEFAULT_DEBUGGER_HUB_URL =
   process.env.NODE_ENV === "development"


### PR DESCRIPTION
## Change Summary

currently if you copy the `.env.sample` file, it will set the debugger url to "" which will then break your frame
