### PR TITLE
feat(frames.js): allow plain object as button definitions so React is not requirement

### DIFF
--- a/.changeset/real-moons-buy.md
+++ b/.changeset/real-moons-buy.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+feat(frames.js): allow plain object as button definitions so React is not requirement

--- a/docs/pages/reference/core/Button.mdx
+++ b/docs/pages/reference/core/Button.mdx
@@ -1,6 +1,6 @@
 # Button
 
-In order to render buttons you should use our `<Button>` component or `button()` helper. Frames.js supports the following button types:
+In order to render buttons you should use our `<Button>` component, `button()` helper or plain objects. Frames.js supports the following button types:
 
 ## Post Button
 
@@ -10,6 +10,12 @@ import { Button, button } from "frames.js/core";
 <Button action="post">Click me</Button>;
 
 button({ action: "post", label: "Click me" });
+
+// plain object
+{
+  action: "post",
+  label: "Click me",
+}
 ```
 
 This button sends a request to a URL on which it was rendered. If you want to navigate to different route in your app, you can use `target` prop which should be set to relative path.
@@ -20,6 +26,13 @@ This button sends a request to a URL on which it was rendered. If you want to na
 </Button>;
 
 button({ action: "post", target: "/next-route", label: "Click me" });
+
+// plain object
+{
+  action: "post",
+  target: "/next-route",
+  label: "Click me",
+}
 ```
 
 The `target` path will be resolved relatively to current URL.
@@ -39,6 +52,13 @@ button({
   target: { query: { foo: "bar" }, pathname: "/next-route" },
   label: "Click me",
 });
+
+// plain object
+{
+  action: "post",
+  target: { query: { foo: "bar" }, pathname: "/next-route" },
+  label: "Click me",
+}
 ```
 
 The state will be available in the frame handler via `ctx.searchParams` e.g.
@@ -68,6 +88,13 @@ button({
   target: { query: { foo: "bar" }, pathname: "/next-route" },
   label: "Click me",
 });
+
+// plain object
+{
+  action: "post_redirect",
+  target: { query: { foo: "bar" }, pathname: "/next-route" },
+  label: "Click me",
+}
 ```
 
 ## Link Button
@@ -82,6 +109,13 @@ import { Button, button } from "frames.js/core";
 </Button>;
 
 button({ action: "link", target: "https://google.com", label: "Click me" });
+
+// plain object
+{
+  action: "link",
+  target: "https://google.com",
+  label: "Click me",
+}
 ```
 
 ## Mint Button
@@ -112,6 +146,17 @@ button({
   }),
   label: "Mint",
 });
+
+// plain object
+{
+  action: "mint",
+  target: getTokenUrl({
+    address: "0x8f5ed2503b71e8492badd21d5aaef75d65ac0042",
+    chain: zora,
+    tokenId: "3",
+  }),
+  label: "Mint",
+}
 ```
 
 ## Tx Button
@@ -131,6 +176,14 @@ button({
   post_url: "/tx-success",
   label: "Buy storage",
 });
+
+// plain object
+{
+  action: "tx",
+  target: "/txdata",
+  post_url: "/tx-success",
+  label: "Buy storage",
+}
 ```
 
 ### Transaction data

--- a/docs/pages/reference/core/Button.mdx
+++ b/docs/pages/reference/core/Button.mdx
@@ -1,13 +1,15 @@
 # Button
 
-In order to render buttons you should use our `<Button>` component. Frames.js supports the following button types:
+In order to render buttons you should use our `<Button>` component or `button()` helper. Frames.js supports the following button types:
 
 ## Post Button
 
 ```tsx
-import { Button } from "frames.js/core";
+import { Button, button } from "frames.js/core";
 
 <Button action="post">Click me</Button>;
+
+button({ action: "post", label: "Click me" });
 ```
 
 This button sends a request to a URL on which it was rendered. If you want to navigate to different route in your app, you can use `target` prop which should be set to relative path.
@@ -15,7 +17,9 @@ This button sends a request to a URL on which it was rendered. If you want to na
 ```tsx
 <Button action="post" target="/next-route">
   Click me
-</Button>
+</Button>;
+
+button({ action: "post", target: "/next-route", label: "Click me" });
 ```
 
 The `target` path will be resolved relatively to current URL.
@@ -28,7 +32,13 @@ The `target` path will be resolved relatively to current URL.
   target={{ query: { foo: "bar" }, pathname: "/next-route" }}
 >
   Click me
-</Button>
+</Button>;
+
+button({
+  action: "post",
+  target: { query: { foo: "bar" }, pathname: "/next-route" },
+  label: "Click me",
+});
 ```
 
 The state will be available in the frame handler via `ctx.searchParams` e.g.
@@ -44,7 +54,7 @@ Post redirect button is a special kind of `post` button that when users clicks t
 It accepts same props as `post` button.
 
 ```tsx
-import { Button } from "frames.js/core";
+import { Button, button } from "frames.js/core";
 
 <Button
   action="post_redirect"
@@ -52,6 +62,12 @@ import { Button } from "frames.js/core";
 >
   Click me
 </Button>;
+
+button({
+  action: "post_redirect",
+  target: { query: { foo: "bar" }, pathname: "/next-route" },
+  label: "Click me",
+});
 ```
 
 ## Link Button
@@ -59,11 +75,13 @@ import { Button } from "frames.js/core";
 Link button navigates to external URL when clicked.
 
 ```tsx
-import { Button } from "frames.js/core";
+import { Button, button } from "frames.js/core";
 
 <Button action="link" target="https://google.com">
   Click me
 </Button>;
+
+button({ action: "link", target: "https://google.com", label: "Click me" });
 ```
 
 ## Mint Button
@@ -71,7 +89,7 @@ import { Button } from "frames.js/core";
 Mint button creates a new token when clicked.
 
 ```tsx
-import { Button } from "frames.js/core";
+import { Button, button } from "frames.js/core";
 import { getTokenUrl } from "frames.js";
 
 <Button
@@ -84,6 +102,16 @@ import { getTokenUrl } from "frames.js";
 >
   Mint
 </Button>;
+
+button({
+  action: "mint",
+  target: getTokenUrl({
+    address: "0x8f5ed2503b71e8492badd21d5aaef75d65ac0042",
+    chain: zora,
+    tokenId: "3",
+  }),
+  label: "Mint",
+});
 ```
 
 ## Tx Button
@@ -91,11 +119,18 @@ import { getTokenUrl } from "frames.js";
 Tx button requests transaction data from `target` when clicked, and send the transaction ID to the frame's `post_url` or the button's `post_url` if it is set.
 
 ```tsx
-import { Button } from "frames.js/core";
+import { Button, button } from "frames.js/core";
 
 <Button action="tx" target="/txdata" post_url="/tx-success">
   Buy storage
 </Button>;
+
+button({
+  action: "tx",
+  target: "/txdata",
+  post_url: "/tx-success",
+  label: "Buy storage",
+});
 ```
 
 ### Transaction data
@@ -141,6 +176,13 @@ export const GET = frames(async (ctx) => {
       <Button action="tx" target="/txdata" post_url="/tx-success">
         Execute
       </Button>,
+      // or using button helper
+      button({
+        action: "tx",
+        target: "/txdata",
+        post_url: "/tx-success",
+        label: "Execute",
+      }),
     ],
   };
 })
@@ -166,6 +208,12 @@ const handleRequest = frames(async (ctx) => {
         >
           View on block explorer
         </Button>,
+        // or using button helper
+        button({
+          action: "link",
+          target: `https://www.onceupon.gg/tx/${ctx.message.transactionId}`,
+          label: "View on block explorer",
+        }),
       ],
     };
   }

--- a/packages/frames.js/src/core/button.ts
+++ b/packages/frames.js/src/core/button.ts
@@ -1,0 +1,25 @@
+import type { FramePlainObjectButtonElement } from "./types";
+
+/**
+ * Defines a button in a typesafe way without the React requirement. This is just a helper to have IDE autocompletion.
+ *
+ * @example
+ * ```ts
+ * import { button } from "frames.js/core";
+ *
+ * {
+ *    buttons: [
+ *      button({
+ *        action: "post",
+ *        label: "Click me",
+ *        target: "/",
+ *    }),
+ *   ],
+ * }
+ * ```
+ */
+export function button(
+  props: FramePlainObjectButtonElement
+): FramePlainObjectButtonElement {
+  return props;
+}

--- a/packages/frames.js/src/core/index.ts
+++ b/packages/frames.js/src/core/index.ts
@@ -2,6 +2,7 @@ export { createFrames } from "./createFrames";
 export { concurrentMiddleware } from "../middleware/concurrentMiddleware";
 export { composeMiddleware } from "./composeMiddleware";
 export { Button } from "./components";
+export { button } from "./button";
 export { redirect } from "./redirect";
 export { error } from "./error";
 export { transaction } from "./transaction";

--- a/packages/frames.js/src/core/types.ts
+++ b/packages/frames.js/src/core/types.ts
@@ -1,6 +1,6 @@
 import type { ImageResponse } from "@vercel/og";
 import type { ClientProtocolId } from "../types";
-import type { Button } from "./components";
+import type { Button, ButtonProps } from "./components";
 
 export type JsonObject = { [Key in string]: JsonValue } & {
   [Key in string]?: JsonValue | undefined;
@@ -59,8 +59,22 @@ export type FramesContext<TState extends JsonValue | undefined = JsonValue> = {
 
 type AllowedFramesContextShape = Record<string, any>;
 
-export type FrameButtonElement = React.ReactComponentElement<typeof Button>;
-type AllowedFrameButtonItems = FrameButtonElement | null | undefined | boolean;
+type RemapChildrenToLabelProps<T> = T extends any
+  ? Omit<T, "children"> & {
+      /** A 256-byte string which is label of the button */
+      label: string;
+    }
+  : never;
+
+export type FramePlainObjectButtonElement =
+  RemapChildrenToLabelProps<ButtonProps>;
+export type FrameButtonElement = React.ReactElement<ButtonProps, typeof Button>;
+export type AllowedFrameButtonItems =
+  | FramePlainObjectButtonElement
+  | FrameButtonElement
+  | null
+  | undefined
+  | boolean;
 
 /**
  * Frame definition, this is rendered by the frames

--- a/packages/frames.js/src/middleware/renderResponse.test.tsx
+++ b/packages/frames.js/src/middleware/renderResponse.test.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/require-await -- middleware expects async functions */
 /* eslint-disable testing-library/render-result-naming-convention -- we are not using react testing library here */
 import * as vercelOg from "@vercel/og";
-import { FRAMES_META_TAGS_HEADER } from "../core";
+import { FRAMES_META_TAGS_HEADER, button } from "../core";
 import { Button } from "../core/components";
 import { error } from "../core/error";
 import { redirect } from "../core/redirect";
@@ -341,10 +341,7 @@ describe("renderResponse middleware", () => {
     const result = await render(context, async () => {
       return {
         image: <div>My image</div>,
-        buttons: [
-          // this is not a proper object created by React.createElement()
-          { action: "link", props: "invalid" },
-        ],
+        buttons: [{}],
       };
     });
 
@@ -576,5 +573,37 @@ describe("renderResponse middleware", () => {
       "fc:frame:button:2": "Click me 2",
       "fc:frame:button:2:target": expect.any(String) as string,
     });
+  });
+
+  it("renders buttons specified by plain objects", async () => {
+    context.request = new Request("https://example.com", {
+      headers: {
+        Accept: FRAMES_META_TAGS_HEADER,
+      },
+    });
+    const result = await render(context, async () => {
+      return {
+        image: <div>My image</div>,
+        buttons: [
+          button({
+            action: "tx",
+            label: "Tx button",
+            target: "/tx",
+            post_url: "/txid",
+          }),
+        ],
+      };
+    });
+
+    const json = (await (result as Response).json()) as Record<string, string>;
+
+    expect(json["fc:frame:button:1"]).toBe("Tx button");
+    expect(json["fc:frame:button:1:action"]).toBe("tx");
+    expect(json["fc:frame:button:1:target"]).toBe(
+      "https://example.com/tx?__bi=1-p"
+    );
+    expect(json["fc:frame:button:1:post_url"]).toBe(
+      "https://example.com/txid?__bi=1-p"
+    );
   });
 });

--- a/packages/frames.js/src/middleware/renderResponse.test.tsx
+++ b/packages/frames.js/src/middleware/renderResponse.test.tsx
@@ -600,7 +600,7 @@ describe("renderResponse middleware", () => {
     expect(json["fc:frame:button:1"]).toBe("Tx button");
     expect(json["fc:frame:button:1:action"]).toBe("tx");
     expect(json["fc:frame:button:1:target"]).toBe(
-      "https://example.com/tx?__bi=1-p"
+      "https://example.com/tx?__bi=1-tx"
     );
     expect(json["fc:frame:button:1:post_url"]).toBe(
       "https://example.com/txid?__bi=1-p"


### PR DESCRIPTION
## Change Summary

This PR adds support for plain object button definitions. Also new `button()` helper is provided to improve typescript experience.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
