### PR TITLE
fix(frames.js): remove double calling route handler in state middleware

### DIFF
--- a/.changeset/bright-spies-rush.md
+++ b/.changeset/bright-spies-rush.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix(frames.js): do not call the route handler twice if the handler doesn't return a frame definition

--- a/packages/frames.js/src/core/transaction.ts
+++ b/packages/frames.js/src/core/transaction.ts
@@ -1,9 +1,19 @@
 import type { TransactionTargetResponse } from "../types";
 
+export class TransactionResponse extends Response {
+  constructor(txdata: TransactionTargetResponse) {
+    super(JSON.stringify(txdata), {
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+}
+
 /**
  * Returns a response containing the transaction data conforming to the frames spec.
  * @param txdata - The transaction data to return.
  */
 export function transaction(txdata: TransactionTargetResponse): Response {
-  return Response.json(txdata);
+  return new TransactionResponse(txdata);
 }

--- a/packages/frames.js/src/core/utils.test.ts
+++ b/packages/frames.js/src/core/utils.test.ts
@@ -1,5 +1,5 @@
 import {
-  generatePostButtonTargetURL,
+  generateButtonTargetURL,
   parseButtonInformationFromTargetURL,
   resolveBaseUrl,
   generateTargetURL,
@@ -103,7 +103,7 @@ describe("generatePostButtonTargetURL", () => {
     expected.searchParams.set("__bi", "1-p");
 
     expect(
-      generatePostButtonTargetURL({
+      generateButtonTargetURL({
         target: undefined,
         buttonAction: "post",
         buttonIndex: 1,
@@ -118,7 +118,7 @@ describe("generatePostButtonTargetURL", () => {
     expected.searchParams.set("__bi", "1-p");
 
     expect(
-      generatePostButtonTargetURL({
+      generateButtonTargetURL({
         buttonAction: "post",
         buttonIndex: 1,
         baseUrl: new URL("http://test.com"),
@@ -132,7 +132,7 @@ describe("generatePostButtonTargetURL", () => {
     expected.searchParams.set("__bi", "1-p");
 
     expect(
-      generatePostButtonTargetURL({
+      generateButtonTargetURL({
         target: "/test",
         buttonAction: "post",
         buttonIndex: 1,
@@ -147,7 +147,7 @@ describe("generatePostButtonTargetURL", () => {
     expected.searchParams.set("__bi", "1-p");
 
     expect(
-      generatePostButtonTargetURL({
+      generateButtonTargetURL({
         buttonAction: "post",
         buttonIndex: 1,
         baseUrl: new URL("http://test.com"),
@@ -161,7 +161,7 @@ describe("generatePostButtonTargetURL", () => {
     expected.searchParams.set("__bi", "1-pr");
 
     expect(
-      generatePostButtonTargetURL({
+      generateButtonTargetURL({
         target: "/test",
         buttonAction: "post_redirect",
         buttonIndex: 1,

--- a/packages/frames.js/src/core/utils.ts
+++ b/packages/frames.js/src/core/utils.ts
@@ -5,7 +5,10 @@ import type { FrameDefinition, FrameRedirect, JsonValue } from "./types";
 const buttonActionToCode = {
   post: "p",
   post_redirect: "pr",
-};
+  tx: "tx",
+} as const;
+
+type ButtonActions = keyof typeof buttonActionToCode;
 
 const BUTTON_INFORMATION_SEARCH_PARAM_NAME = "__bi";
 
@@ -40,13 +43,8 @@ function isValidButtonIndex(index: unknown): index is 1 | 2 | 3 | 4 {
   );
 }
 
-function isValidButtonAction(
-  action: unknown
-): action is "post" | "post_redirect" {
-  return (
-    typeof action === "string" &&
-    (action === "post" || action === "post_redirect")
-  );
+function isValidButtonAction(action: unknown): action is ButtonActions {
+  return typeof action === "string" && action in buttonActionToCode;
 }
 
 export function generateTargetURL({
@@ -92,17 +90,17 @@ export function generateTargetURL({
 }
 
 /**
- * This function generates fully qualified URL for post and post_redirect buttons
+ * This function generates fully qualified URL for post, post_redirect and tx buttons
  * that also encodes the button type and button value so we can use that on next frame.
  */
-export function generatePostButtonTargetURL({
+export function generateButtonTargetURL({
   buttonIndex,
   buttonAction,
   target,
   baseUrl,
 }: {
   buttonIndex: 1 | 2 | 3 | 4;
-  buttonAction: "post" | "post_redirect";
+  buttonAction: ButtonActions;
   target: string | UrlObject | undefined;
   baseUrl: URL;
 }): string {
@@ -118,7 +116,7 @@ export function generatePostButtonTargetURL({
 }
 
 type ButtonInformation = {
-  action: "post" | "post_redirect";
+  action: ButtonActions;
   index: 1 | 2 | 3 | 4;
 };
 
@@ -153,7 +151,7 @@ export function parseButtonInformationFromTargetURL(
   const index = parseInt(buttonIndex, 10);
   const action = Object.entries(buttonActionToCode).find(
     ([, value]) => value === buttonActionCode
-  )?.[0] as "post" | "post_redirect";
+  )?.[0];
 
   if (!isValidButtonIndex(index) || !isValidButtonAction(action)) {
     return undefined;

--- a/packages/frames.js/src/middleware/framesjsMiddleware.test.ts
+++ b/packages/frames.js/src/middleware/framesjsMiddleware.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console -- we are expecting console.log usage */
 import { redirect } from "../core/redirect";
 import type { FramesContext } from "../core/types";
-import { generatePostButtonTargetURL, resolveBaseUrl } from "../core/utils";
+import { generateButtonTargetURL, resolveBaseUrl } from "../core/utils";
 import { framesjsMiddleware } from "./framesjsMiddleware";
 
 describe("framesjsMiddleware middleware", () => {
@@ -24,7 +24,7 @@ describe("framesjsMiddleware middleware", () => {
   });
 
   it("provides pressedButton to context if post button is detected", async () => {
-    const url = generatePostButtonTargetURL({
+    const url = generateButtonTargetURL({
       buttonAction: "post",
       buttonIndex: 1,
       baseUrl: new URL("https://example.com"),
@@ -52,7 +52,7 @@ describe("framesjsMiddleware middleware", () => {
   });
 
   it("provides pressedButton to context if post redirect button is detected", async () => {
-    const url = generatePostButtonTargetURL({
+    const url = generateButtonTargetURL({
       buttonAction: "post_redirect",
       buttonIndex: 1,
       baseUrl: new URL("https://example.com"),
@@ -80,7 +80,7 @@ describe("framesjsMiddleware middleware", () => {
 
   it("warns if the response for post redirect button is not a redirect Response", async () => {
     console.warn = jest.fn();
-    const url = generatePostButtonTargetURL({
+    const url = generateButtonTargetURL({
       buttonAction: "post_redirect",
       buttonIndex: 1,
       baseUrl: new URL("https://example.com"),
@@ -104,7 +104,7 @@ describe("framesjsMiddleware middleware", () => {
 
   it("warns if the response for post button is a redirect definition", async () => {
     console.warn = jest.fn();
-    const url = generatePostButtonTargetURL({
+    const url = generateButtonTargetURL({
       buttonAction: "post",
       buttonIndex: 1,
       baseUrl: new URL("https://example.com"),
@@ -129,7 +129,7 @@ describe("framesjsMiddleware middleware", () => {
 
   it("warns if the response for post button is a Response", async () => {
     console.warn = jest.fn();
-    const url = generatePostButtonTargetURL({
+    const url = generateButtonTargetURL({
       buttonAction: "post",
       buttonIndex: 1,
       baseUrl: new URL("https://example.com"),
@@ -155,7 +155,7 @@ describe("framesjsMiddleware middleware", () => {
   });
 
   it('does nothing if the request method is not "POST"', async () => {
-    const url = generatePostButtonTargetURL({
+    const url = generateButtonTargetURL({
       buttonAction: "post",
       buttonIndex: 1,
       baseUrl: new URL("https://example.com"),

--- a/packages/frames.js/src/middleware/framesjsMiddleware.ts
+++ b/packages/frames.js/src/middleware/framesjsMiddleware.ts
@@ -1,3 +1,4 @@
+import { TransactionResponse } from "../core/transaction";
 import type { FramesMiddleware } from "../core/types";
 import {
   isFrameRedirect,
@@ -13,7 +14,7 @@ type FramesjsMiddlewareContext = {
    */
   pressedButton?:
     | {
-        action: "post" | "post_redirect";
+        action: "post" | "post_redirect" | "tx";
         index: 1 | 2 | 3 | 4;
       }
     | undefined;
@@ -56,6 +57,17 @@ export function framesjsMiddleware(): FramesMiddleware<
         // eslint-disable-next-line no-console -- provide feedback to the developer
         console.warn(
           "The clicked button action was post, but the response was not a frame definition"
+        );
+      }
+    } else if (pressedButton?.action === "tx") {
+      // we support only TransactionResponse as result for tx button
+      if (
+        !(result instanceof TransactionResponse) ||
+        !(result instanceof Response)
+      ) {
+        // eslint-disable-next-line no-console -- provide feedback to the developer
+        console.warn(
+          "The clicked button action was tx, but the response was not a transaction data response. Please use transaction() function to return transaction data."
         );
       }
     }

--- a/packages/frames.js/src/middleware/renderResponse.test.tsx
+++ b/packages/frames.js/src/middleware/renderResponse.test.tsx
@@ -428,7 +428,7 @@ describe("renderResponse middleware", () => {
     expect(json["fc:frame:button:1"]).toBe("Tx button");
     expect(json["fc:frame:button:1:action"]).toBe("tx");
     expect(json["fc:frame:button:1:target"]).toBe(
-      "https://example.com/tx?__bi=1-p"
+      "https://example.com/tx?__bi=1-tx"
     );
     expect(json["fc:frame:button:1:post_url"]).toBe(
       "https://example.com/txid?__bi=1-p"

--- a/packages/frames.js/src/middleware/renderResponse.ts
+++ b/packages/frames.js/src/middleware/renderResponse.ts
@@ -10,7 +10,7 @@ import type {
   FramesMiddleware,
 } from "../core/types";
 import {
-  generatePostButtonTargetURL,
+  generateButtonTargetURL,
   generateTargetURL,
   isFrameRedirect,
 } from "../core/utils";
@@ -169,14 +169,14 @@ export function renderResponse(): FramesMiddleware<any, Record<string, any>> {
                 return {
                   action: props.action,
                   label: props.children,
-                  target: generatePostButtonTargetURL({
+                  target: generateButtonTargetURL({
                     buttonIndex: (i + 1) as 1 | 2 | 3 | 4,
-                    buttonAction: "post",
+                    buttonAction: props.action,
                     target: props.target,
                     baseUrl: context.baseUrl,
                   }).toString(),
                   post_url: props.post_url
-                    ? generatePostButtonTargetURL({
+                    ? generateButtonTargetURL({
                         buttonIndex: (i + 1) as 1 | 2 | 3 | 4,
                         buttonAction: "post",
                         target: props.post_url,
@@ -189,7 +189,7 @@ export function renderResponse(): FramesMiddleware<any, Record<string, any>> {
                 return {
                   action: props.action,
                   label: props.children,
-                  target: generatePostButtonTargetURL({
+                  target: generateButtonTargetURL({
                     buttonIndex: (i + 1) as 1 | 2 | 3 | 4,
                     buttonAction: props.action,
                     target: props.target,

--- a/packages/frames.js/src/middleware/stateMiddleware.test.ts
+++ b/packages/frames.js/src/middleware/stateMiddleware.test.ts
@@ -209,4 +209,21 @@ describe("stateMiddleware", () => {
       });
     });
   });
+
+  it("calls next only once and returns result as is if the result is not a frame definition", async () => {
+    const state = { foo: "bar" };
+    const ctx = {
+      message: { state: JSON.stringify(state) },
+      initialState: {},
+      request: new Request("http://localhost", { method: "POST" }),
+    };
+    const mw = stateMiddleware();
+    const res = new Response();
+    const next = jest.fn(() => Promise.resolve(res));
+
+    const result = await mw(ctx as unknown as FramesContext, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(result).toBe(res);
+  });
 });


### PR DESCRIPTION
## Change Summary

This PR removes double calling `next()` in `stateMiddleware` if the first call did not return frame definition, which caused route handler to be called twice.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary


Closes #395