### PR TITLE
fix(debugger): SIGNER_URL environment variables bug

### DIFF
--- a/.changeset/shiny-zebras-perform.md
+++ b/.changeset/shiny-zebras-perform.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/debugger": patch
+---
+
+fix(debugger): SIGNER_URL environment variables bug

--- a/packages/debugger/bin/debugger.js
+++ b/packages/debugger/bin/debugger.js
@@ -45,9 +45,18 @@ const args = yargs(hideBin(process.argv))
     default: process.env.NEXT_PUBLIC_HOST,
   }).argv;
 
-process.env.FARCASTER_DEVELOPER_MNEMONIC = args["farcaster-developer-mnemonic"];
-process.env.FARCASTER_DEVELOPER_ID = args["farcaster-developer-fid"];
-process.env.SIGNER_URL = args["signer-url"];
+if (args["farcaster-developer-mnemonic"]) {
+  process.env.FARCASTER_DEVELOPER_MNEMONIC =
+    args["farcaster-developer-mnemonic"];
+}
+
+if (args["farcaster-developer-fid"]) {
+  process.env.FARCASTER_DEVELOPER_ID = args["farcaster-developer-fid"];
+}
+
+if (args["signer-url"]) {
+  process.env.SIGNER_URL = args["signer-url"];
+}
 
 const dev = false;
 const hostname = "localhost";


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Fixes an issue where creating a farcaster signer would not work unless a signer URL is specified when running the debugger.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
