### PR TITLE
fix(frames.js): warn invalid og image

### DIFF
--- a/.changeset/tidy-days-joke.md
+++ b/.changeset/tidy-days-joke.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix(frames.js): warn invalid og image

--- a/packages/frames.js/src/frame-parsers/farcaster.ts
+++ b/packages/frames.js/src/frame-parsers/farcaster.ts
@@ -59,12 +59,13 @@ export function parseFarcasterFrame(
   if (!parsedFrame.ogImage) {
     reporter.warn("og:image", 'Missing meta tag "og:image"');
   } else {
-    frame.ogImage = validate(
-      reporter,
-      "og:image",
-      validateFrameImage,
-      parsedFrame.ogImage
-    );
+    try {
+      frame.ogImage = validateFrameImage(parsedFrame.ogImage);
+    } catch (error) {
+      if (error instanceof Error) {
+        reporter.warn("og:image", error.message);
+      }
+    }
   }
 
   if (parsedFrame.imageAspectRatio) {

--- a/packages/frames.js/src/frame-parsers/open-frames.ts
+++ b/packages/frames.js/src/frame-parsers/open-frames.ts
@@ -103,12 +103,13 @@ export function parseOpenFramesFrame(
   if (!parsedFrame.ogImage) {
     reporter.warn("og:image", 'Missing meta tag "og:image"');
   } else {
-    frame.ogImage = validate(
-      reporter,
-      "og:image",
-      validateFrameImage,
-      parsedFrame.ogImage
-    );
+    try {
+      frame.ogImage = validateFrameImage(parsedFrame.ogImage);
+    } catch (error) {
+      if (error instanceof Error) {
+        reporter.warn("og:image", error.message);
+      }
+    }
   }
 
   if (parsedFrame.imageAspectRatio) {


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Fixes an error where frame parsing would fail due to invalid OG image despite the rest of the frame being valid.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
