### PR TITLE
fix: open frames fall back to farcaster buttons if "of:button" not found

### DIFF
--- a/.changeset/six-eels-destroy.md
+++ b/.changeset/six-eels-destroy.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix: fall back to fc:button if of:button not present in openframes parser

--- a/packages/frames.js/src/frame-parsers/open-frames.test.ts
+++ b/packages/frames.js/src/frame-parsers/open-frames.test.ts
@@ -35,10 +35,10 @@ describe("open frames frame parser", () => {
     });
   });
 
-  it('falls back to farcaster frame data if "of:accepts:farcaster" is present', () => {
+  it('falls back to farcaster frame data if "of:accepts:" is present and "of:" tags are not', () => {
     const $ = load(`
     <meta name="of:version" content="vNext"/>
-    <meta name="of:accepts:farcaster" content="vNext"/>
+    <meta name="of:accepts:myproto" content="1.0.0"/>
     <meta name="og:image" content="http://example.com/og-image.png"/>
     <title>Test</title>
     `);
@@ -48,6 +48,12 @@ describe("open frames frame parser", () => {
         farcasterFrame: {
           version: "vNext",
           image: "http://example.com/farcaster-image.png",
+          buttons: [
+            {
+              action: "post",
+              label: "Post",
+            },
+          ],
         },
         fallbackPostUrl,
         reporter,
@@ -56,11 +62,12 @@ describe("open frames frame parser", () => {
       status: "success",
       reports: {},
       frame: {
-        accepts: [{ id: "farcaster", version: "vNext" }],
+        accepts: [{ id: "myproto", version: "1.0.0" }],
         version: "vNext",
         image: "http://example.com/farcaster-image.png",
         ogImage: "http://example.com/og-image.png",
         postUrl: fallbackPostUrl,
+        buttons: [{ action: "post", label: "Post" }],
       },
     });
   });

--- a/packages/frames.js/src/frame-parsers/open-frames.ts
+++ b/packages/frames.js/src/frame-parsers/open-frames.ts
@@ -28,7 +28,6 @@ export function parseOpenFramesFrame(
   $: CheerioAPI,
   { fallbackPostUrl, farcasterFrame, reporter }: Options
 ): ParseResult {
-  let fallsBackToFarcaster = false;
   let fallbackFrameData: Partial<Frame> = {};
 
   // parse accepts
@@ -40,10 +39,6 @@ export function parseOpenFramesFrame(
 
       if (!protocol) {
         reporter.error(property, "Missing protocol id");
-      }
-
-      if (protocol === "farcaster") {
-        fallsBackToFarcaster = true;
       }
 
       return {
@@ -59,9 +54,7 @@ export function parseOpenFramesFrame(
     );
   }
 
-  if (fallsBackToFarcaster) {
-    fallbackFrameData = farcasterFrame;
-  }
+  fallbackFrameData = farcasterFrame;
 
   const parsedFrame: ParsedOpenFramesFrame = {
     accepts,

--- a/packages/frames.js/src/frame-parsers/open-frames.ts
+++ b/packages/frames.js/src/frame-parsers/open-frames.ts
@@ -149,7 +149,13 @@ export function parseOpenFramesFrame(
     );
   }
 
-  const parsedButtons = parseButtons($, reporter, "of:button");
+  const parsedButtonsOf = parseButtons($, reporter, "of:button");
+
+  const parsedButtons =
+    fallbackFrameData.buttons &&
+    fallbackFrameData.buttons?.length > parsedButtonsOf.length
+      ? fallbackFrameData.buttons
+      : parsedButtonsOf;
 
   if (parsedButtons.length > 0) {
     frame.buttons = parsedButtons as typeof frame.buttons;


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Fix issue where open frames parsing was not falling back to fc attributes if present

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
