### PR TITLE
feat(render): allow to override behaviour of redirects, fetch and link button clicks

### DIFF
--- a/.changeset/cool-seals-repair.md
+++ b/.changeset/cool-seals-repair.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/render": patch
+---
+
+feat(@frames.js/render): allow to override fetch, onRedirect and onLinkButtonClick behaviours

--- a/docs/pages/reference/render/use-frame.mdx
+++ b/docs/pages/reference/render/use-frame.mdx
@@ -14,6 +14,12 @@ The connected wallet address of the user.
 
 If true, the frame will not be signed before being sent to the frameActionProxy. This is useful for frames that don't verify signatures.
 
+### `fetchFn`
+
+- Type: `typeof fetch`
+
+The custom fetch function to use instead of native [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
+
 ### `frameActionProxy`
 
 - Type: `string`
@@ -50,11 +56,23 @@ The initial frame. if not specified will fetch it from the url prop.
 
 A function that can be used to customize how errors are reported to a user, by default it logs errors using `console.error()`.
 
+### `onLinkButtonClick`
+
+- Type: `(button: FrameButtonLink) => void`
+
+A function to handle link button presses by default it opens the link in new tab using `window.open()` if browser environment, otherwise it just logs the link.
+
 ### `onMint`
 
 - Type: `(t: onMintArgs) => void`
 
 A function to handle mint buttons.
+
+### `onRedirect`
+
+- Type: `(url: string) => void`
+
+A function to handle redirect responses from the frame. This happens when you click a [`post_redirect` button](/reference/core/Button#post-redirect-button). By default it opens the link in new tab using `window.open()` if browser environment, otherwise it just logs the link.
 
 ### `onTransaction`
 

--- a/packages/render/src/types.ts
+++ b/packages/render/src/types.ts
@@ -1,6 +1,7 @@
 import type {
   Frame,
   FrameButton,
+  FrameButtonLink,
   FrameButtonPost,
   FrameButtonTx,
   SupportedParsingSpecification,
@@ -14,6 +15,43 @@ import type { FarcasterFrameContext } from "./farcaster/frames";
 export type OnTransactionFunc = (
   t: OnTransactionArgs
 ) => Promise<`0x${string}` | null>;
+
+export type UseFetchFrameOptions = {
+  stackDispatch: React.Dispatch<FrameReducerActions>;
+  specification: SupportedParsingSpecification;
+  /**
+   * URL or path to the frame proxy handling GET requests.
+   */
+  frameGetProxy: string;
+  /**
+   * URL or path to the frame proxy handling POST requests.
+   */
+  frameActionProxy: string;
+  /**
+   * Extra payload to be sent with the POST request.
+   */
+  extraButtonRequestPayload?: Record<string, unknown>;
+  signFrameAction: (
+    isDangerousSkipSigning: boolean,
+    actionContext: SignerStateActionContext<any, any>
+  ) => ReturnType<SignerStateInstance["signFrameAction"]>;
+  onTransaction: OnTransactionFunc;
+  homeframeUrl: string | undefined | null;
+  /**
+   * This function can be used to customize how error is reported to the user.
+   */
+  onError?: (error: Error) => void;
+  /**
+   * Custom fetch compatible function used to make requests.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
+   */
+  fetchFn: typeof fetch;
+  /**
+   * This function is called when the frame returns a redirect in response to post_redirect button click.
+   */
+  onRedirect: (location: URL) => void;
+};
 
 export type UseFrameOptions<
   SignerStorageType = object,
@@ -58,7 +96,11 @@ export type UseFrameOptions<
    * This function can be used to customize how error is reported to the user.
    */
   onError?: (error: Error) => void;
-};
+  /**
+   * This function can be used to customize how the link button click is handled.
+   */
+  onLinkButtonClick?: (button: FrameButtonLink) => void;
+} & Partial<Pick<UseFetchFrameOptions, "fetchFn" | "onRedirect">>;
 
 export type SignerStateActionContext<
   SignerStorageType = object,


### PR DESCRIPTION
## Change Summary

This PR allows:
- [x] - override `fetch` function, this is useful if you want to use `useQuery()` from `@tanstack/react-query` for example.
- [x] - link button click behaviour, useful for react native compatibility
- [x] - redirect behaviour in response to `post_redirect` button click
- [x] - all `window` references are now checked by condition so the fallback behaviour of above mentioned is not failing in react native

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
