### PR TITLE
fix: collapsed frame rules

### DIFF
--- a/packages/render/src/collapsed-frame-ui.tsx
+++ b/packages/render/src/collapsed-frame-ui.tsx
@@ -1,6 +1,6 @@
 import type { ImgHTMLAttributes } from "react";
 import React, { useState } from "react";
-import type { Frame, FrameButton } from "frames.js";
+import type { Frame } from "frames.js";
 import type { FrameTheme, FrameState } from "./types";
 
 const defaultTheme: Required<FrameTheme> = {
@@ -121,65 +121,27 @@ export function CollapsedFrameUI({
           {new URL(currentFrame.url).hostname}
         </span>
       </div>
-      {!!frame && !!frame.buttons && frame.buttons.length > 0 ? (
+      {!!frame && !!frame.buttons ? (
         <div className="flex items-center shrink-0">
-          {frame.buttons
-            .slice(0, 1)
-            .map((frameButton: FrameButton, index: number) => (
-              <button
-                type="button"
-                disabled={isLoading}
-                className={`p-2 ${
-                  isLoading ? "bg-gray-100" : ""
-                } border text-sm text-gray-800 rounded`}
-                style={{
-                  flex: "1 1 0px",
-                  // fixme: hover style
-                  backgroundColor: resolvedTheme.buttonBg,
-                  borderColor: resolvedTheme.buttonBorderColor,
-                  color: resolvedTheme.buttonColor,
-                  cursor: isLoading ? undefined : "pointer",
-                }}
-                onClick={() => {
-                  Promise.resolve(
-                    frameState.onButtonPress(
-                      // Partial frame could have enough data to handle button press
-                      frame as Frame,
-                      frameButton,
-                      index
-                    )
-                  ).catch((e: unknown) => {
-                    // eslint-disable-next-line no-console -- provide feedback to the user
-                    console.error(e);
-                  });
-                }}
-                // eslint-disable-next-line react/no-array-index-key -- this is fine
-                key={index}
-              >
-                {frameButton.action === "mint" ? `⬗ ` : ""}
-                {frameButton.label}
-                {frameButton.action === "tx" ? (
-                  <svg
-                    aria-hidden="true"
-                    focusable="false"
-                    role="img"
-                    viewBox="0 0 16 16"
-                    className="ml-1 mb-[2px] text-gray-400 inline-block select-none align-text-middle overflow-visible"
-                    width="12"
-                    height="12"
-                    fill="currentColor"
-                  >
-                    <path d="M9.504.43a1.516 1.516 0 0 1 2.437 1.713L10.415 5.5h2.123c1.57 0 2.346 1.909 1.22 3.004l-7.34 7.142a1.249 1.249 0 0 1-.871.354h-.302a1.25 1.25 0 0 1-1.157-1.723L5.633 10.5H3.462c-1.57 0-2.346-1.909-1.22-3.004L9.503.429Zm1.047 1.074L3.286 8.571A.25.25 0 0 0 3.462 9H6.75a.75.75 0 0 1 .694 1.034l-1.713 4.188 6.982-6.793A.25.25 0 0 0 12.538 7H9.25a.75.75 0 0 1-.683-1.06l2.008-4.418.003-.006a.036.036 0 0 0-.004-.009l-.006-.006-.008-.001c-.003 0-.006.002-.009.004Z" />
-                  </svg>
-                ) : (
-                  ""
-                )}
-                {frameButton.action === "post_redirect" ||
-                frameButton.action === "link"
-                  ? ` ↗`
-                  : ""}
-              </button>
-            ))}
+          <button
+            type="button"
+            disabled={isLoading}
+            className={`p-2 ${
+              isLoading ? "bg-gray-100" : ""
+            } border text-sm text-gray-800 rounded`}
+            style={{
+              flex: "1 1 0px",
+              // fixme: hover style
+              backgroundColor: resolvedTheme.buttonBg,
+              borderColor: resolvedTheme.buttonBorderColor,
+              color: resolvedTheme.buttonColor,
+              cursor: isLoading ? undefined : "pointer",
+            }}
+          >
+            {frame.buttons.length === 1 && frame.buttons[0].label.length < 12
+              ? frame.buttons[0].label
+              : "View"}
+          </button>
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Add collapsed frame button rendereding rules according to https://warpcast.com/horsefacts.eth/0x34188947
- Show "View" button if text > 12 characters or multiple buttons present
- Disable button presses (collapsed frame always opens frame modal)

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
