### PR TITLE
fix(debugger): respect target passed to signers

### DIFF
--- a/.changeset/nice-pianos-smash.md
+++ b/.changeset/nice-pianos-smash.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/debugger": patch
+---
+
+fix(debugger): respect target url passed to signers

--- a/packages/debugger/app/hooks/use-lens-identity.tsx
+++ b/packages/debugger/app/hooks/use-lens-identity.tsx
@@ -263,8 +263,7 @@ export function useLensIdentity(): LensSignerInstance {
           postType: actionContext.transactionId
             ? "post"
             : actionContext.frameButton.action,
-          postUrl:
-            actionContext.frameButton.target ?? actionContext.target ?? "",
+          postUrl: actionContext.target ?? "",
         });
 
         return {

--- a/packages/debugger/app/hooks/use-xmtp-identity.tsx
+++ b/packages/debugger/app/hooks/use-xmtp-identity.tsx
@@ -166,7 +166,7 @@ export function useXmtpIdentity(): XmtpSignerInstance {
         postType: actionContext.transactionId
           ? "post"
           : actionContext.frameButton.action,
-        postUrl: actionContext.frameButton.target ?? "",
+        postUrl: actionContext.target ?? "",
         specification: "openframes",
       });
 


### PR DESCRIPTION
## Change Summary

This PR fixes XMTP and Lens signers to actually respect `target` passed to them and not infer it from button. This fixes an issue where buttons like `tx` have 2 possible targets.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary

Fixes #433
