### PR TITLE
feat: anonymous open frames signer

### DIFF
--- a/.changeset/odd-bats-jam.md
+++ b/.changeset/odd-bats-jam.md
@@ -1,0 +1,7 @@
+---
+"template-next-starter-with-examples": patch
+"frames.js": patch
+"@frames.js/debugger": patch
+---
+
+feat: anoynmous open frames signer

--- a/packages/debugger/app/components/protocol-config-button.tsx
+++ b/packages/debugger/app/components/protocol-config-button.tsx
@@ -17,6 +17,7 @@ import { cn } from "../lib/utils";
 import FarcasterSignerWindow from "./farcaster-signer-config";
 import { forwardRef, useMemo, useState } from "react";
 import { WithTooltip } from "./with-tooltip";
+import { useAnonymousIdentity } from "../hooks/use-anonymous-identity";
 
 export type ProtocolConfiguration =
   | {
@@ -29,6 +30,10 @@ export type ProtocolConfiguration =
     }
   | {
       protocol: "xmtp";
+      specification: "openframes";
+    }
+  | {
+      protocol: "anonymous";
       specification: "openframes";
     };
 
@@ -45,6 +50,10 @@ export const protocolConfigurationMap: Record<string, ProtocolConfiguration> = {
     protocol: "lens",
     specification: "openframes",
   },
+  anonymous: {
+    protocol: "anonymous",
+    specification: "openframes",
+  },
 };
 
 type ProtocolConfigurationButtonProps = {
@@ -53,6 +62,7 @@ type ProtocolConfigurationButtonProps = {
   farcasterSignerState: ReturnType<typeof useFarcasterIdentity>;
   xmtpSignerState: ReturnType<typeof useXmtpIdentity>;
   lensSignerState: ReturnType<typeof useLensIdentity>;
+  anonymousSignerState: ReturnType<typeof useAnonymousIdentity>;
   farcasterFrameContext: ReturnType<typeof useFarcasterFrameContext>;
   xmtpFrameContext: ReturnType<typeof useXmtpFrameContext>;
   lensFrameContext: ReturnType<typeof useLensFrameContext>;
@@ -72,6 +82,7 @@ export const ProtocolConfigurationButton = forwardRef<
       xmtpFrameContext,
       lensFrameContext,
       lensSignerState,
+      anonymousSignerState,
     },
     ref
   ) => {
@@ -92,12 +103,17 @@ export const ProtocolConfigurationButton = forwardRef<
         valid = !!lensSignerState.signer;
       }
 
+      if (value?.protocol === "anonymous") {
+        valid = !!anonymousSignerState.signer;
+      }
+
       return valid;
     }, [
       farcasterSignerState.signer,
       value?.protocol,
       xmtpSignerState.signer,
       lensSignerState.signer,
+      anonymousSignerState,
     ]);
 
     return (
@@ -125,13 +141,18 @@ export const ProtocolConfigurationButton = forwardRef<
         </PopoverTrigger>
         <PopoverContent>
           <Tabs value={value?.protocol} defaultValue="none">
-            <TabsList
-              className={cn(
-                "w-full grid",
-                !value ? "grid-cols-4" : "grid-cols-3"
-              )}
-            >
-              {!value && <TabsTrigger value="none">None</TabsTrigger>}
+            <TabsList className={"w-full grid grid-cols-4"}>
+              <TabsTrigger
+                value="anonymous"
+                onClick={() =>
+                  onChange({
+                    protocol: "anonymous",
+                    specification: "openframes",
+                  })
+                }
+              >
+                None
+              </TabsTrigger>
               <TabsTrigger
                 value="farcaster"
                 onClick={() =>

--- a/packages/debugger/app/debugger-page.tsx
+++ b/packages/debugger/app/debugger-page.tsx
@@ -29,6 +29,7 @@ import { useFarcasterFrameContext } from "./hooks/use-farcaster-context";
 import { useFarcasterIdentity } from "./hooks/use-farcaster-identity";
 import { useXmtpFrameContext } from "./hooks/use-xmtp-context";
 import { useXmtpIdentity } from "./hooks/use-xmtp-identity";
+import { useAnonymousIdentity } from "./hooks/use-anonymous-identity";
 import { MockHubActionContext } from "./utils/mock-hub-utils";
 import {
   ProtocolConfiguration,
@@ -241,6 +242,7 @@ export default function DebuggerPage({
   });
   const xmtpSignerState = useXmtpIdentity();
   const lensSignerState = useLensIdentity();
+  const anonymousSignerState = useAnonymousIdentity();
 
   const farcasterFrameContext = useFarcasterFrameContext({
     fallbackContext: fallbackFrameContext,
@@ -260,6 +262,8 @@ export default function DebuggerPage({
       pubId: "0x01-0x01",
     },
   });
+
+  const anonymousFrameContext = {};
 
   const onTransaction: OnTransactionFunc = useCallback(
     async ({ transactionData }) => {
@@ -440,10 +444,18 @@ export default function DebuggerPage({
     frameContext: lensFrameContext.frameContext,
   });
 
+  const anonymousFrameState = useFrame({
+    ...useFrameConfig,
+    signerState: anonymousSignerState,
+    specification: "openframes",
+    frameContext: anonymousFrameContext,
+  });
+
   const selectedFrameState = {
     farcaster: farcasterFrameState,
     xmtp: xmtpFrameState,
     lens: lensFrameState,
+    anonymous: anonymousFrameState,
   }[protocolConfiguration?.protocol ?? "farcaster"];
 
   return (
@@ -580,6 +592,7 @@ export default function DebuggerPage({
             value={protocolConfiguration}
             farcasterSignerState={farcasterSignerState}
             xmtpSignerState={xmtpSignerState}
+            anonymousSignerState={anonymousSignerState}
             farcasterFrameContext={farcasterFrameContext}
             xmtpFrameContext={xmtpFrameContext}
             ref={selectProtocolButtonRef}

--- a/packages/debugger/app/frames/route.ts
+++ b/packages/debugger/app/frames/route.ts
@@ -72,14 +72,6 @@ export async function POST(req: NextRequest): Promise<Response> {
   const specification =
     req.nextUrl.searchParams.get("specification") ?? "farcaster";
 
-  console.log({
-    body,
-    isPostRedirect,
-    isTransactionRequest,
-    postUrl,
-    specification,
-  });
-
   if (!isSpecificationValid(specification)) {
     return Response.json({ message: "Invalid specification" }, { status: 400 });
   }

--- a/packages/debugger/app/frames/route.ts
+++ b/packages/debugger/app/frames/route.ts
@@ -72,6 +72,14 @@ export async function POST(req: NextRequest): Promise<Response> {
   const specification =
     req.nextUrl.searchParams.get("specification") ?? "farcaster";
 
+  console.log({
+    body,
+    isPostRedirect,
+    isTransactionRequest,
+    postUrl,
+    specification,
+  });
+
   if (!isSpecificationValid(specification)) {
     return Response.json({ message: "Invalid specification" }, { status: 400 });
   }

--- a/packages/debugger/app/hooks/use-anonymous-identity.tsx
+++ b/packages/debugger/app/hooks/use-anonymous-identity.tsx
@@ -19,7 +19,7 @@ export function useAnonymousIdentity(): AnonymousSignerInstance {
         postType: actionContext.transactionId
           ? "post"
           : actionContext.frameButton.action,
-        postUrl: actionContext.frameButton.target ?? "",
+        postUrl: actionContext.target ?? "",
         specification: "openframes",
       });
 

--- a/packages/debugger/app/hooks/use-anonymous-identity.tsx
+++ b/packages/debugger/app/hooks/use-anonymous-identity.tsx
@@ -1,0 +1,40 @@
+import type { SignerStateInstance } from "@frames.js/render";
+import type { AnonymousOpenFramesRequest } from "frames.js/anonymous";
+
+type AnonymousSignerInstance = SignerStateInstance<
+  {},
+  AnonymousOpenFramesRequest,
+  {}
+>;
+
+export function useAnonymousIdentity(): AnonymousSignerInstance {
+  return {
+    hasSigner: true,
+    onSignerlessFramePress() {
+      return;
+    },
+    signer: {},
+    async signFrameAction(actionContext) {
+      const searchParams = new URLSearchParams({
+        postType: actionContext.transactionId
+          ? "post"
+          : actionContext.frameButton.action,
+        postUrl: actionContext.frameButton.target ?? "",
+        specification: "openframes",
+      });
+
+      const result = {
+        body: {
+          untrustedData: {
+            ...actionContext,
+            unixTimestamp: Date.now(),
+          },
+          clientProtocol: "anonymous@1.0",
+        },
+        searchParams,
+      };
+
+      return result;
+    },
+  };
+}

--- a/packages/frames.js/package.json
+++ b/packages/frames.js/package.json
@@ -147,6 +147,16 @@
         "default": "./dist/lens/index.cjs"
       }
     },
+    "./anonymous": {
+      "import": {
+        "types": "./dist/anonymous/index.d.ts",
+        "default": "./dist/anonymous/index.js"
+      },
+      "require": {
+        "types": "./dist/anonymous/index.d.cts",
+        "default": "./dist/anonymous/index.cjs"
+      }
+    },
     "./core": {
       "import": {
         "types": "./dist/core/index.d.ts",

--- a/packages/frames.js/src/anonymous/index.ts
+++ b/packages/frames.js/src/anonymous/index.ts
@@ -1,0 +1,44 @@
+export type AnonymousFrameMessageReturnType = {
+  buttonIndex: number;
+  state?: string;
+  inputText?: string;
+  unixTimestamp: number;
+};
+
+export type AnonymousOpenFramesRequest = {
+  clientProtocol: string;
+  untrustedData: AnonymousFrameMessageReturnType;
+};
+
+export function isAnonymousFrameActionPayload(
+  body: unknown
+): body is AnonymousOpenFramesRequest {
+  return Boolean(
+    body &&
+      typeof body === "object" &&
+      "untrustedData" in body &&
+      typeof body.untrustedData === "object" &&
+      body.untrustedData &&
+      "buttonIndex" in body.untrustedData &&
+      body.untrustedData.buttonIndex &&
+      "clientProtocol" in body &&
+      typeof body.clientProtocol === "string" &&
+      body.clientProtocol.startsWith("anonymous@")
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/require-await -- we need to return a promise
+export async function getAnonymousFrameMessage(
+  body: unknown
+): Promise<AnonymousFrameMessageReturnType | undefined> {
+  if (!isAnonymousFrameActionPayload(body)) {
+    return undefined;
+  }
+
+  return {
+    buttonIndex: body.untrustedData.buttonIndex,
+    state: body.untrustedData.state,
+    inputText: body.untrustedData.inputText,
+    unixTimestamp: body.untrustedData.unixTimestamp,
+  } as const;
+}

--- a/packages/frames.js/src/middleware/openframes.ts
+++ b/packages/frames.js/src/middleware/openframes.ts
@@ -7,8 +7,22 @@ import type {
   JsonValue,
 } from "../core/types";
 import { isFrameDefinition } from "../core/utils";
+import {
+  getAnonymousFrameMessage,
+  isAnonymousFrameActionPayload,
+} from "../anonymous";
 
 type OpenFrameMessage = any;
+
+const deafultClientProtocolHandler: ClientProtocolHandler = {
+  isValidPayload: isAnonymousFrameActionPayload,
+  getFrameMessage: getAnonymousFrameMessage,
+};
+
+const defaultClientProtocol: ClientProtocolId = {
+  id: "anonymous",
+  version: "1.0",
+};
 
 export type OpenFramesMessageContext<T = OpenFrameMessage> = {
   message?: Partial<T>;
@@ -59,19 +73,24 @@ async function nextInjectAcceptedClient({
   return result;
 }
 
-export function openframes<T = OpenFrameMessage>({
-  clientProtocol: clientProtocolRaw,
-  handler,
-}: {
-  /**
-   * Validator and and handler for frame messages from a supported client protocol.
-   * `clientProtocol` is the ID of the client protocol in the form of a ClientProtocolId object or a string of the shape `"id@version"`
-   * Handler is an object containing a frame message validator and handler
-   * The output of the handler is added to the context as `message`
-   */
-  clientProtocol: ClientProtocolId | `${string}@${string}`;
-  handler: ClientProtocolHandler<T>;
-}): FramesMiddleware<any, OpenFramesMessageContext<T>> {
+export function openframes<T = OpenFrameMessage>(
+  {
+    clientProtocol: clientProtocolRaw,
+    handler,
+  }: {
+    /**
+     * Validator and and handler for frame messages from a supported client protocol.
+     * `clientProtocol` is the ID of the client protocol in the form of a ClientProtocolId object or a string of the shape `"id@version"`
+     * Handler is an object containing a frame message validator and handler
+     * The output of the handler is added to the context as `message`
+     */
+    clientProtocol: ClientProtocolId | `${string}@${string}`;
+    handler: ClientProtocolHandler<T>;
+  } = {
+    clientProtocol: defaultClientProtocol,
+    handler: deafultClientProtocolHandler,
+  }
+): FramesMiddleware<any, OpenFramesMessageContext<T>> {
   return async (context, next) => {
     let clientProtocol: ClientProtocolId;
 

--- a/packages/frames.js/src/middleware/openframes.ts
+++ b/packages/frames.js/src/middleware/openframes.ts
@@ -14,7 +14,7 @@ import {
 
 type OpenFrameMessage = any;
 
-const deafultClientProtocolHandler: ClientProtocolHandler = {
+const defaultClientProtocolHandler: ClientProtocolHandler = {
   isValidPayload: isAnonymousFrameActionPayload,
   getFrameMessage: getAnonymousFrameMessage,
 };
@@ -79,7 +79,7 @@ export function openframes<T = OpenFrameMessage>(
     handler,
   }: {
     /**
-     * Validator and and handler for frame messages from a supported client protocol.
+     * Validator and handler for frame messages from a supported client protocol.
      * `clientProtocol` is the ID of the client protocol in the form of a ClientProtocolId object or a string of the shape `"id@version"`
      * Handler is an object containing a frame message validator and handler
      * The output of the handler is added to the context as `message`
@@ -88,7 +88,7 @@ export function openframes<T = OpenFrameMessage>(
     handler: ClientProtocolHandler<T>;
   } = {
     clientProtocol: defaultClientProtocol,
-    handler: deafultClientProtocolHandler,
+    handler: defaultClientProtocolHandler,
   }
 ): FramesMiddleware<any, OpenFramesMessageContext<T>> {
   return async (context, next) => {

--- a/templates/next-starter-with-examples/app/examples/multi-protocol/frames/frames.ts
+++ b/templates/next-starter-with-examples/app/examples/multi-protocol/frames/frames.ts
@@ -55,5 +55,6 @@ export const frames = createFrames({
         },
       },
     }),
+    openframes(),
   ],
 });

--- a/templates/next-starter-with-examples/app/examples/multi-protocol/frames/who-am-i/route.tsx
+++ b/templates/next-starter-with-examples/app/examples/multi-protocol/frames/who-am-i/route.tsx
@@ -23,7 +23,7 @@ export const POST = frames(async (ctx) => {
   return {
     image: (
       <div tw="flex p-5">
-        You are {walletAddress} from {ctx.clientProtocol?.id}
+        You are {walletAddress || "anonymous"} from {ctx.clientProtocol?.id}
       </div>
     ),
     buttons: [


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
- Adds support for `of:clientProtocol:anonymous` in frames.js `frames.js/anonymous` 
- Sets default open frames middleware call to use anonymous client protocol if no arguments specified
- Adds support for anonymous signers in frames.js debugger
- Updates `multi-protocol` example to accept anonymous open frames requests

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
