### PR TITLE
fix(render): no signer required for client side button actions

### DIFF
--- a/.changeset/nine-pears-lie.md
+++ b/.changeset/nine-pears-lie.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/render": patch
+---
+
+fix(render): don't trigger onSignerlessFramePress for client side buttons (mint, tx)

--- a/packages/render/src/use-frame.tsx
+++ b/packages/render/src/use-frame.tsx
@@ -227,7 +227,11 @@ export function useFrame<
     index: number,
     fetchFrameOverride: typeof fetchFrame = fetchFrame
   ): Promise<void> {
-    if (!signerState.hasSigner && !dangerousSkipSigning) {
+    // Button actions that are handled without server interaction don't require signer
+    const clientSideActions = ["mint", "link"];
+    const buttonRequiresAuth = !clientSideActions.includes(frameButton.action);
+
+    if (!signerState.hasSigner && !dangerousSkipSigning && buttonRequiresAuth) {
       signerState.onSignerlessFramePress();
       // don't continue, let the app handle
       return;


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Don't trigger onSignerlessFramePress for client side buttons (mint, tx) as they do not make a call to the frame server.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
