### PR TITLE
feat: allow to override style props type

### DIFF
--- a/packages/debugger/app/components/frame-ui.tsx
+++ b/packages/debugger/app/components/frame-ui.tsx
@@ -3,8 +3,11 @@ import { cn } from "@/lib/utils";
 import { FrameUI as BaseFrameUI } from "@frames.js/render/ui";
 import { MessageSquareIcon, AlertOctagonIcon, ZapIcon } from "lucide-react";
 import Image from "next/image";
+import React from "react";
 
-type Props = React.ComponentProps<typeof BaseFrameUI>;
+type Props = React.ComponentProps<
+  typeof BaseFrameUI<{ className?: string; style?: React.CSSProperties }>
+>;
 
 const components: Props["components"] = {
   Button(

--- a/packages/render/src/ui/frame.base.tsx
+++ b/packages/render/src/ui/frame.base.tsx
@@ -26,7 +26,7 @@ export type BaseFrameUIProps<TStylingProps extends Record<string, unknown>> = {
    */
   enableImageDebugging?: boolean;
   components: FrameUIComponents<TStylingProps>;
-  theme: FrameUIComponentStylingProps<TStylingProps>;
+  theme?: Partial<FrameUIComponentStylingProps<TStylingProps>> | undefined;
   /**
    * Called when an error occurs in response to frame button press
    *
@@ -68,7 +68,10 @@ export function BaseFrameUI<TStylingProps extends Record<string, unknown>>({
   }, [currentFrameStackItem, onError]);
 
   if (!frameState.homeframeUrl) {
-    return components.Error({ message: "Missing frame url" }, theme.Error);
+    return components.Error(
+      { message: "Missing frame url" },
+      theme?.Error || ({} as TStylingProps)
+    );
   }
 
   if (!currentFrameStackItem) {
@@ -91,7 +94,7 @@ export function BaseFrameUI<TStylingProps extends Record<string, unknown>>({
             message: "Failed to load frame",
             error: currentFrameStackItem.requestError,
           },
-          theme.Error
+          theme?.Error || ({} as TStylingProps)
         );
       }
 
@@ -129,7 +132,10 @@ export function BaseFrameUI<TStylingProps extends Record<string, unknown>>({
           isImageLoading,
         };
       } else {
-        return components.Error({ message: "Invalid frame" }, theme.Error);
+        return components.Error(
+          { message: "Invalid frame" },
+          theme?.Error || ({} as TStylingProps)
+        );
       }
 
       break;
@@ -154,7 +160,7 @@ export function BaseFrameUI<TStylingProps extends Record<string, unknown>>({
               frameState: frameUiState,
               dimensions: rootDimensionsRef.current ?? null,
             },
-            theme.LoadingScreen
+            theme?.LoadingScreen || ({} as TStylingProps)
           )
         : null,
       buttonsContainer:
@@ -195,11 +201,11 @@ export function BaseFrameUI<TStylingProps extends Record<string, unknown>>({
                         });
                       },
                     },
-                    theme.Button
+                    theme?.Button || ({} as TStylingProps)
                   )
                 ),
               },
-              theme.ButtonsContainer
+              theme?.ButtonsContainer || ({} as TStylingProps)
             ),
       imageContainer: components.ImageContainer(
         {
@@ -223,7 +229,7 @@ export function BaseFrameUI<TStylingProps extends Record<string, unknown>>({
                   aspectRatio: frameUiState.frame.imageAspectRatio ?? "1.91:1",
                   onImageLoadEnd,
                 },
-            theme.Image
+            theme?.Image || ({} as TStylingProps)
           ),
           messageTooltip:
             currentFrameStackItem.status === "message"
@@ -238,11 +244,11 @@ export function BaseFrameUI<TStylingProps extends Record<string, unknown>>({
                       currentFrameStackItem
                     ),
                   },
-                  theme.MessageTooltip
+                  theme?.MessageTooltip || ({} as TStylingProps)
                 )
               : null,
         },
-        theme.ImageContainer
+        theme?.ImageContainer || ({} as TStylingProps)
       ),
       textInputContainer:
         frameUiState.status === "loading" ||
@@ -262,12 +268,12 @@ export function BaseFrameUI<TStylingProps extends Record<string, unknown>>({
                     },
                     value: frameState.inputText,
                   },
-                  theme.TextInput
+                  theme?.TextInput || ({} as TStylingProps)
                 ),
               },
-              theme.TextInputContainer
+              theme?.TextInputContainer || ({} as TStylingProps)
             ),
     },
-    theme.Root
+    theme?.Root || ({} as TStylingProps)
   );
 }

--- a/packages/render/src/ui/frame.base.tsx
+++ b/packages/render/src/ui/frame.base.tsx
@@ -1,5 +1,11 @@
 import type { Frame } from "frames.js";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  createElement as reactCreateElement,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import type { FrameState } from "../types";
 import type {
   FrameUIComponents,
@@ -33,6 +39,14 @@ export type BaseFrameUIProps<TStylingProps extends Record<string, unknown>> = {
    * @defaultValue console.error()
    */
   onError?: (error: Error) => void;
+  /**
+   * Custom createElement function to use when rendering components.
+   *
+   * This is useful for libraries like Nativewind that require a custom createElement function.
+   *
+   * @defaultValue React.createElement
+   */
+  createElement?: typeof reactCreateElement;
 };
 
 export function BaseFrameUI<TStylingProps extends Record<string, unknown>>({
@@ -43,6 +57,7 @@ export function BaseFrameUI<TStylingProps extends Record<string, unknown>>({
   enableImageDebugging = false,
   // eslint-disable-next-line no-console -- provide at least some feedback to the user
   onError = console.error,
+  createElement = reactCreateElement,
 }: BaseFrameUIProps<TStylingProps>): JSX.Element | null {
   const [isImageLoading, setIsImageLoading] = useState(true);
   const { currentFrameStackItem } = frameState;
@@ -151,6 +166,7 @@ export function BaseFrameUI<TStylingProps extends Record<string, unknown>>({
 
   return components.Root(
     {
+      createElement,
       frameState: frameUiState,
       dimensions: isLoading ? rootDimensionsRef.current ?? null : null,
       ref: rootRef,

--- a/packages/render/src/ui/index.tsx
+++ b/packages/render/src/ui/index.tsx
@@ -1,9 +1,8 @@
-import React, { forwardRef, useImperativeHandle, useRef } from "react";
+import React, { forwardRef, useImperativeHandle, useMemo, useRef } from "react";
 import { BaseFrameUI, type BaseFrameUIProps } from "./frame.base";
 import type {
   FrameRootContainerProps,
   FrameUIComponents,
-  FrameUIComponentStylingProps,
   RootContainerElement,
 } from "./types";
 
@@ -67,143 +66,142 @@ const RootContainer = forwardRef<
 
 RootContainer.displayName = "RootContainer";
 
-const defaultComponents: FrameUIComponents<StylingProps> = {
-  Button(props, stylingProps) {
-    return (
-      <button
-        {...stylingProps}
-        key={props.index}
-        disabled={props.isDisabled}
-        onClick={props.onPress}
-        type="button"
-      >
-        {props.frameButton.action === "mint" && "⬗ "}
-        {props.frameButton.label}
-        {props.frameButton.action === "tx" && (
-          <svg
-            aria-hidden="true"
-            focusable="false"
-            role="img"
-            viewBox="0 0 16 16"
-            className="ml-1 mb-[2px] text-gray-400 inline-block select-none align-text-middle overflow-visible"
-            width="12"
-            height="12"
-            fill="currentColor"
-          >
-            <path d="M9.504.43a1.516 1.516 0 0 1 2.437 1.713L10.415 5.5h2.123c1.57 0 2.346 1.909 1.22 3.004l-7.34 7.142a1.249 1.249 0 0 1-.871.354h-.302a1.25 1.25 0 0 1-1.157-1.723L5.633 10.5H3.462c-1.57 0-2.346-1.909-1.22-3.004L9.503.429Zm1.047 1.074L3.286 8.571A.25.25 0 0 0 3.462 9H6.75a.75.75 0 0 1 .694 1.034l-1.713 4.188 6.982-6.793A.25.25 0 0 0 12.538 7H9.25a.75.75 0 0 1-.683-1.06l2.008-4.418.003-.006a.036.036 0 0 0-.004-.009l-.006-.006-.008-.001c-.003 0-.006.002-.009.004Z" />
-          </svg>
-        )}
-        {(props.frameButton.action === "post_redirect" ||
-          props.frameButton.action === "link") &&
-          ` ↗`}
-      </button>
-    );
-  },
-  ButtonsContainer(props, stylingProps) {
-    return <div {...stylingProps}>{props.buttons}</div>;
-  },
-  Error(props, stylingProps) {
-    return <div {...stylingProps}>{props.message}</div>;
-  },
-  Image(props, stylingProps) {
-    const aspectRatio = props.aspectRatio.replace(":", "/");
+function isCssProperties(value: unknown): value is React.CSSProperties {
+  return typeof value === "object" && value !== null;
+}
 
-    return (
-      <img
-        {...stylingProps}
-        data-aspect-ratio={aspectRatio}
-        style={{
-          "--frame-image-aspect-ratio": aspectRatio,
-          ...stylingProps.style,
-        }}
-        onLoad={props.onImageLoadEnd}
-        onError={props.onImageLoadEnd}
-        src={props.status === "frame-loading" ? undefined : props.src}
-        alt="Frame"
-      />
-    );
-  },
-  ImageContainer(props, stylingProps) {
-    const aspectRatio = props.aspectRatio.replace(":", "/");
+function createDefaultComponents<
+  TStylingProps extends Record<string, unknown>,
+>(): FrameUIComponents<TStylingProps> {
+  return {
+    Button(props, stylingProps) {
+      return (
+        <button
+          {...stylingProps}
+          key={props.index}
+          disabled={props.isDisabled}
+          onClick={props.onPress}
+          type="button"
+        >
+          {props.frameButton.action === "mint" && "⬗ "}
+          {props.frameButton.label}
+          {props.frameButton.action === "tx" && (
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              role="img"
+              viewBox="0 0 16 16"
+              className="ml-1 mb-[2px] text-gray-400 inline-block select-none align-text-middle overflow-visible"
+              width="12"
+              height="12"
+              fill="currentColor"
+            >
+              <path d="M9.504.43a1.516 1.516 0 0 1 2.437 1.713L10.415 5.5h2.123c1.57 0 2.346 1.909 1.22 3.004l-7.34 7.142a1.249 1.249 0 0 1-.871.354h-.302a1.25 1.25 0 0 1-1.157-1.723L5.633 10.5H3.462c-1.57 0-2.346-1.909-1.22-3.004L9.503.429Zm1.047 1.074L3.286 8.571A.25.25 0 0 0 3.462 9H6.75a.75.75 0 0 1 .694 1.034l-1.713 4.188 6.982-6.793A.25.25 0 0 0 12.538 7H9.25a.75.75 0 0 1-.683-1.06l2.008-4.418.003-.006a.036.036 0 0 0-.004-.009l-.006-.006-.008-.001c-.003 0-.006.002-.009.004Z" />
+            </svg>
+          )}
+          {(props.frameButton.action === "post_redirect" ||
+            props.frameButton.action === "link") &&
+            ` ↗`}
+        </button>
+      );
+    },
+    ButtonsContainer(props, stylingProps) {
+      return <div {...stylingProps}>{props.buttons}</div>;
+    },
+    Error(props, stylingProps) {
+      return <div {...stylingProps}>{props.message}</div>;
+    },
+    Image(props, stylingProps) {
+      const aspectRatio = props.aspectRatio.replace(":", "/");
 
-    return (
-      <div
-        {...stylingProps}
-        style={{
-          "--frame-image-aspect-ratio": aspectRatio,
-          aspectRatio,
-          ...stylingProps.style,
-        }}
-      >
-        {props.image}
-        {props.messageTooltip}
-      </div>
-    );
-  },
-  LoadingScreen(props, stylingProps) {
-    return <div {...stylingProps}>Loading...</div>;
-  },
-  MessageTooltip(props, stylingProps) {
-    return (
-      <div {...stylingProps} data-status={props.status}>
-        {props.message}
-      </div>
-    );
-  },
-  Root(props, stylingProps) {
-    return <RootContainer {...props} {...stylingProps} />;
-  },
-  TextInput(props, stylingProps) {
-    return (
-      <input
-        {...stylingProps}
-        disabled={props.isDisabled}
-        onChange={(e) => {
-          props.onChange(e.target.value);
-        }}
-        placeholder={props.placeholder}
-        value={props.value}
-        type="text"
-      />
-    );
-  },
-  TextInputContainer(props, stylingProps) {
-    return <div {...stylingProps}>{props.textInput}</div>;
-  },
-};
+      return (
+        <img
+          {...stylingProps}
+          data-aspect-ratio={aspectRatio}
+          style={{
+            "--frame-image-aspect-ratio": aspectRatio,
+            ...(isCssProperties(stylingProps.style) && stylingProps.style),
+          }}
+          onLoad={props.onImageLoadEnd}
+          onError={props.onImageLoadEnd}
+          src={props.status === "frame-loading" ? undefined : props.src}
+          alt="Frame"
+        />
+      );
+    },
+    ImageContainer(props, stylingProps) {
+      const aspectRatio = props.aspectRatio.replace(":", "/");
 
-const defaultStyles: FrameUIComponentStylingProps<StylingProps> = {
-  Button: {},
-  ButtonsContainer: {},
-  Error: {},
-  Image: {},
-  ImageContainer: {},
-  LoadingScreen: {},
-  MessageTooltip: {},
-  Root: {},
-  TextInput: {},
-  TextInputContainer: {},
-};
+      return (
+        <div
+          {...stylingProps}
+          style={{
+            "--frame-image-aspect-ratio": aspectRatio,
+            aspectRatio,
+            ...(isCssProperties(stylingProps.style) && stylingProps.style),
+          }}
+        >
+          {props.image}
+          {props.messageTooltip}
+        </div>
+      );
+    },
+    LoadingScreen(props, stylingProps) {
+      return <div {...stylingProps}>Loading...</div>;
+    },
+    MessageTooltip(props, stylingProps) {
+      return (
+        <div {...stylingProps} data-status={props.status}>
+          {props.message}
+        </div>
+      );
+    },
+    Root(props, stylingProps) {
+      return <RootContainer {...props} {...stylingProps} />;
+    },
+    TextInput(props, stylingProps) {
+      return (
+        <input
+          {...stylingProps}
+          disabled={props.isDisabled}
+          onChange={(e) => {
+            props.onChange(e.target.value);
+          }}
+          placeholder={props.placeholder}
+          value={props.value}
+          type="text"
+        />
+      );
+    },
+    TextInputContainer(props, stylingProps) {
+      return <div {...stylingProps}>{props.textInput}</div>;
+    },
+  };
+}
 
-type StyledBaseUIProps = BaseFrameUIProps<StylingProps>;
-type FrameUIProps = Omit<
-  StyledBaseUIProps,
-  "components" | "theme" | "computeRootDimensions"
+type FrameUIProps<TStylingProps extends Record<string, unknown>> = Omit<
+  BaseFrameUIProps<TStylingProps>,
+  "components"
 > & {
-  components?: Partial<StyledBaseUIProps["components"]>;
-  theme?: Partial<StyledBaseUIProps["theme"]>;
+  /**
+   * Components should be memoized to avoid re-rendering the entire UI
+   */
+  components?: Partial<FrameUIComponents<TStylingProps>>;
 };
 
-export function FrameUI(props: FrameUIProps): JSX.Element {
-  const components = {
-    ...defaultComponents,
-    ...props.components,
-  };
+export function FrameUI<
+  TStylingProps extends Record<string, unknown> = StylingProps,
+>(props: FrameUIProps<TStylingProps>): JSX.Element {
+  const defaultComponents = useMemo(
+    () => createDefaultComponents<TStylingProps>(),
+    []
+  );
+  const components = useMemo(() => {
+    return {
+      ...defaultComponents,
+      ...props.components,
+    };
+  }, [defaultComponents, props.components]);
 
-  const theme = {
-    ...defaultStyles,
-    ...props.theme,
-  };
-
-  return <BaseFrameUI {...props} components={components} theme={theme} />;
+  return <BaseFrameUI<TStylingProps> {...props} components={components} />;
 }

--- a/packages/render/src/ui/types.ts
+++ b/packages/render/src/ui/types.ts
@@ -1,5 +1,5 @@
 import type { Frame, FrameButton } from "frames.js";
-import type { ReactElement } from "react";
+import type { createElement, ReactElement } from "react";
 
 /**
  * Allows to override styling props on all component of the Frame UI
@@ -154,6 +154,13 @@ export type RootContainerElement = {
 };
 
 export type FrameRootContainerProps = {
+  /**
+   * Used to create elements.
+   *
+   * This allows to change the implementation of createElement.
+   * For example NativeWind needs to use their own implementation.
+   */
+  createElement: typeof createElement;
   /**
    * Dimensions of the root when button has been pressed.
    * Available only if frame or frame's image is in loading state.


### PR DESCRIPTION
## Change Summary

This PR:
- makes FrameUI generic so user can override style props types
- allows to change `createElement` used to produce jsx, this handles issues when NativeWind essentially uses their own wrapper around createElement

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [ ] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
