### PR TITLE
feat(frames.js): add walletAddress method to context

### DIFF
--- a/.changeset/modern-feet-punch.md
+++ b/.changeset/modern-feet-punch.md
@@ -1,0 +1,6 @@
+---
+"template-next-starter-with-examples": patch
+"frames.js": patch
+---
+
+feat(frames.js): add walletAddress() method to context so user can get wallet address associated with frame message

--- a/docs/pages/reference/core/createFrames.mdx
+++ b/docs/pages/reference/core/createFrames.mdx
@@ -290,6 +290,12 @@ The request object that was passed to the request handler.
 
 The URL object that was parsed from the request.
 
+## `walletAddress`
+
+- Type: `() => Promise<string | undefined>`
+
+A function that returns the wallet address of the user. If the user is not authenticated or initial frame is being rendered, it returns `undefined`.
+
 ### `searchParams`
 
 - Type: `Record<string, string>`

--- a/packages/debugger/app/hooks/use-anonymous-identity.tsx
+++ b/packages/debugger/app/hooks/use-anonymous-identity.tsx
@@ -23,18 +23,19 @@ export function useAnonymousIdentity(): AnonymousSignerInstance {
         specification: "openframes",
       });
 
-      const result = {
+      return {
         body: {
           untrustedData: {
             ...actionContext,
             unixTimestamp: Date.now(),
+            walletAddress() {
+              return Promise.resolve(undefined);
+            },
           },
           clientProtocol: "anonymous@1.0",
         },
         searchParams,
       };
-
-      return result;
     },
   };
 }

--- a/packages/frames.js/src/anonymous/index.ts
+++ b/packages/frames.js/src/anonymous/index.ts
@@ -1,9 +1,12 @@
-export type AnonymousFrameMessageReturnType = {
-  buttonIndex: number;
-  state?: string;
-  inputText?: string;
-  unixTimestamp: number;
-};
+import type { MessageWithWalletAddressImplementation } from "../middleware/walletAddressMiddleware";
+
+export type AnonymousFrameMessageReturnType =
+  MessageWithWalletAddressImplementation & {
+    buttonIndex: number;
+    state?: string;
+    inputText?: string;
+    unixTimestamp: number;
+  };
 
 export type AnonymousOpenFramesRequest = {
   clientProtocol: string;
@@ -40,5 +43,8 @@ export async function getAnonymousFrameMessage(
     state: body.untrustedData.state,
     inputText: body.untrustedData.inputText,
     unixTimestamp: body.untrustedData.unixTimestamp,
+    walletAddress() {
+      return Promise.resolve(undefined);
+    },
   } as const;
 }

--- a/packages/frames.js/src/core/createFrames.ts
+++ b/packages/frames.js/src/core/createFrames.ts
@@ -1,6 +1,7 @@
 import { coreMiddleware } from "../middleware/default";
 import { imagesWorkerMiddleware } from "../middleware/images-worker";
 import { stateMiddleware } from "../middleware/stateMiddleware";
+import { walletAddressMiddleware } from "../middleware/walletAddressMiddleware";
 import { composeMiddleware } from "./composeMiddleware";
 import type {
   FramesContext,
@@ -71,6 +72,8 @@ export function createFrames<
       ...globalMiddleware,
       stateMiddleware<TState>(),
       // @ts-expect-error hard to type internally so skipping for now
+      walletAddressMiddleware(),
+      // @ts-expect-error hard to type internally so skipping for now
       ...perRouteMiddleware,
       // @ts-expect-error hard to type internally so skipping for now
       async function handlerMiddleware(ctx) {
@@ -93,6 +96,13 @@ export function createFrames<
         url: new URL(request.url),
         baseUrl: resolveBaseUrl(request, url, basePath),
         stateSigningSecret: stateSigningSecret || signingSecret,
+        walletAddress() {
+          // eslint-disable-next-line no-console -- provide feedback
+          console.warn(
+            "Warning (frames.js): `getWalletAddress()` should be implemented"
+          );
+          return Promise.resolve(undefined);
+        },
         debug,
         __debugInfo: {},
       };

--- a/packages/frames.js/src/core/createFrames.ts
+++ b/packages/frames.js/src/core/createFrames.ts
@@ -99,7 +99,7 @@ export function createFrames<
         walletAddress() {
           // eslint-disable-next-line no-console -- provide feedback
           console.warn(
-            "Warning (frames.js): `getWalletAddress()` should be implemented"
+            "Warning (frames.js): `walletAddress()` should be implemented"
           );
           return Promise.resolve(undefined);
         },

--- a/packages/frames.js/src/core/types.ts
+++ b/packages/frames.js/src/core/types.ts
@@ -57,6 +57,12 @@ export type FramesContext<TState extends JsonValue | undefined = JsonValue> = {
   url: URL;
   stateSigningSecret?: string;
   /**
+   * Returns wallet address associated with the request's message
+   *
+   * This method is implemented by internal middleware.
+   */
+  walletAddress: () => Promise<string | undefined>;
+  /**
    * Is debug mode enabled?
    */
   debug: boolean;

--- a/packages/frames.js/src/lens/index.ts
+++ b/packages/frames.js/src/lens/index.ts
@@ -4,6 +4,7 @@ import {
   development,
   production,
 } from "@lens-protocol/client";
+import type { MessageWithWalletAddressImplementation } from "../middleware/walletAddressMiddleware";
 
 type LensFrameRequest = {
   clientProtocol: string;
@@ -37,9 +38,10 @@ type LensFrameVerifiedFields = {
   specVersion: string;
 };
 
-export type LensFrameResponse = LensFrameVerifiedFields & {
-  isValid: boolean;
-};
+export type LensFrameResponse = MessageWithWalletAddressImplementation &
+  LensFrameVerifiedFields & {
+    isValid: boolean;
+  };
 
 export type LensFrameOptions = {
   environment?: "production" | "development";
@@ -102,5 +104,12 @@ export async function getLensFrameMessage(
   return {
     ...typedData.value,
     isValid: response === FrameVerifySignatureResult.Verified,
+    async walletAddress() {
+      const profile = await lensClient.profile.fetch({
+        forProfileId: typedData.value.profileId,
+      });
+
+      return profile?.ownedBy.address;
+    },
   };
 }

--- a/packages/frames.js/src/middleware/farcaster.test.ts
+++ b/packages/frames.js/src/middleware/farcaster.test.ts
@@ -118,6 +118,8 @@ describe("farcaster middleware", () => {
         requesterFid: 123,
         state: JSON.stringify({ test: true }),
         transactionId: undefined,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- safe
+        walletAddress: expect.any(Function),
       },
     });
   });

--- a/packages/frames.js/src/middleware/farcaster.ts
+++ b/packages/frames.js/src/middleware/farcaster.ts
@@ -8,6 +8,7 @@ import {
   RequestBodyNotJSONError,
 } from "../core/errors";
 import type { FramesMiddleware, JsonValue } from "../core/types";
+import type { MessageWithWalletAddressImplementation } from "./walletAddressMiddleware";
 
 function isValidFrameActionPayload(
   value: unknown
@@ -55,7 +56,7 @@ async function decodeFrameActionPayloadFromRequest(
 type FrameMessage = Omit<
   FrameMessageReturnType<{ fetchHubContext: false }>,
   "message"
-> & { state?: JsonValue };
+> & { state?: JsonValue } & MessageWithWalletAddressImplementation;
 
 type FramesMessageContext = {
   message?: FrameMessage;
@@ -82,7 +83,17 @@ export function farcaster(): FramesMiddleware<any, FramesMessageContext> {
       });
 
       return next({
-        message,
+        message: {
+          ...message,
+          walletAddress() {
+            // eslint-disable-next-line no-console -- provide feedback to the developer
+            console.info(
+              "farcaster middleware: walletAddress() called, please ue farcasterHubContext() middleware if you want to access the wallet address"
+            );
+
+            return Promise.resolve(undefined);
+          },
+        },
         clientProtocol: {
           id: "farcaster",
           version: "vNext",

--- a/packages/frames.js/src/middleware/farcasterHubContext.test.ts
+++ b/packages/frames.js/src/middleware/farcasterHubContext.test.ts
@@ -116,6 +116,8 @@ describe("farcasterHubContext middleware", () => {
           requesterFid: 123,
           state: JSON.stringify({ test: true }),
           requesterUserData: expect.anything() as UserDataReturnType,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- safe
+          walletAddress: expect.any(Function),
         }) as unknown,
       })
     );

--- a/packages/frames.js/src/middleware/images-worker/handler.test.tsx
+++ b/packages/frames.js/src/middleware/images-worker/handler.test.tsx
@@ -14,6 +14,9 @@ describe("createImagesWorkerRequestHandler", () => {
     baseUrl: resolveBaseUrl(frameRequest, undefined, "/"),
     __debugInfo: {},
     debug: false,
+    walletAddress() {
+      return Promise.resolve(undefined);
+    },
   };
   const imagesRouteUrl = "https://example.com/image";
 

--- a/packages/frames.js/src/middleware/images-worker/imagesWorker.test.tsx
+++ b/packages/frames.js/src/middleware/images-worker/imagesWorker.test.tsx
@@ -12,6 +12,9 @@ describe("imagesWorker", () => {
     baseUrl: resolveBaseUrl(request, undefined, "/"),
     __debugInfo: {},
     debug: false,
+    walletAddress() {
+      return Promise.resolve(undefined);
+    },
   };
   const imagesRoute = "https://example.com/image";
   const mw = ImagesWorker.imagesWorkerMiddleware({ imagesRoute });

--- a/packages/frames.js/src/middleware/openframes.test.ts
+++ b/packages/frames.js/src/middleware/openframes.test.ts
@@ -85,7 +85,10 @@ describe("openframes middleware", () => {
             console.error("openframes: Could not parse state");
           }
 
-          return { ...result, state };
+          return {
+            ...result,
+            state: state ?? "",
+          };
         },
       },
     });
@@ -123,7 +126,11 @@ describe("openframes middleware", () => {
       handler: {
         isValidPayload: () => false,
         getFrameMessage: () => {
-          return Promise.resolve({});
+          return Promise.resolve({
+            walletAddress() {
+              return Promise.resolve(undefined);
+            },
+          } as const);
         },
       },
     });
@@ -132,7 +139,11 @@ describe("openframes middleware", () => {
       handler: {
         isValidPayload: () => false,
         getFrameMessage: () => {
-          return Promise.resolve({});
+          return Promise.resolve({
+            walletAddress() {
+              return Promise.resolve(undefined);
+            },
+          } as const);
         },
       },
     });
@@ -213,7 +224,12 @@ describe("openframes middleware", () => {
       handler: {
         isValidPayload: () => false,
         getFrameMessage: () => {
-          return Promise.resolve({ test1: true });
+          return Promise.resolve({
+            test1: true,
+            walletAddress() {
+              return Promise.resolve(undefined);
+            },
+          } as const);
         },
       },
     });
@@ -222,7 +238,12 @@ describe("openframes middleware", () => {
       handler: {
         isValidPayload: () => true,
         getFrameMessage: () => {
-          return Promise.resolve({ test2: true });
+          return Promise.resolve({
+            test2: true,
+            walletAddress() {
+              return Promise.resolve(undefined);
+            },
+          } as const);
         },
       },
     });
@@ -296,6 +317,8 @@ describe("openframes middleware", () => {
           buttonIndex: 1,
           inputText: "hello",
           state: { test: true },
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- safe
+          walletAddress: expect.any(Function),
         }) as unknown,
         clientProtocol: {
           id: "xmtp",

--- a/packages/frames.js/src/middleware/openframes.ts
+++ b/packages/frames.js/src/middleware/openframes.ts
@@ -7,29 +7,34 @@ import type {
   JsonValue,
 } from "../core/types";
 import { isFrameDefinition } from "../core/utils";
+import type { AnonymousFrameMessageReturnType } from "../anonymous";
 import {
   getAnonymousFrameMessage,
   isAnonymousFrameActionPayload,
 } from "../anonymous";
+import type { MessageWithWalletAddressImplementation } from "./walletAddressMiddleware";
 
-type OpenFrameMessage = any;
-
-const defaultClientProtocolHandler: ClientProtocolHandler = {
-  isValidPayload: isAnonymousFrameActionPayload,
-  getFrameMessage: getAnonymousFrameMessage,
-};
+const defaultClientProtocolHandler: ClientProtocolHandler<AnonymousFrameMessageReturnType> =
+  {
+    isValidPayload: isAnonymousFrameActionPayload,
+    getFrameMessage: getAnonymousFrameMessage,
+  };
 
 const defaultClientProtocol: ClientProtocolId = {
   id: "anonymous",
   version: "1.0",
 };
 
-export type OpenFramesMessageContext<T = OpenFrameMessage> = {
-  message?: Partial<T>;
+export type OpenFramesMessageContext<
+  T extends MessageWithWalletAddressImplementation,
+> = {
+  message?: T;
   clientProtocol?: ClientProtocolId;
 };
 
-export type ClientProtocolHandler<T = OpenFrameMessage> = {
+export type ClientProtocolHandler<
+  T extends MessageWithWalletAddressImplementation,
+> = {
   getFrameMessage: (body: JsonValue) => Promise<T | undefined> | undefined;
   isValidPayload: (body: JsonValue) => boolean;
 };
@@ -73,7 +78,10 @@ async function nextInjectAcceptedClient({
   return result;
 }
 
-export function openframes<T = OpenFrameMessage>(
+export function openframes<
+  T extends
+    MessageWithWalletAddressImplementation = AnonymousFrameMessageReturnType,
+>(
   {
     clientProtocol: clientProtocolRaw,
     handler,
@@ -88,6 +96,7 @@ export function openframes<T = OpenFrameMessage>(
     handler: ClientProtocolHandler<T>;
   } = {
     clientProtocol: defaultClientProtocol,
+    // @ts-expect-error hard to type internally so skipping for now
     handler: defaultClientProtocolHandler,
   }
 ): FramesMiddleware<any, OpenFramesMessageContext<T>> {

--- a/packages/frames.js/src/middleware/renderResponse.test.tsx
+++ b/packages/frames.js/src/middleware/renderResponse.test.tsx
@@ -57,6 +57,9 @@ describe("renderResponse middleware", () => {
     baseUrl: resolveBaseUrl(request, undefined, "/"),
     __debugInfo: {},
     debug: false,
+    walletAddress() {
+      return Promise.resolve(undefined);
+    },
   };
 
   beforeEach(() => {

--- a/packages/frames.js/src/middleware/walletAddressMiddleware.ts
+++ b/packages/frames.js/src/middleware/walletAddressMiddleware.ts
@@ -29,7 +29,7 @@ type WalletAddressFromMessageMiddlewareContext = Pick<
 /**
  * This middleware handles wallet address extraction from frame message by providing "walletAddress()" method on context.
  *
- * Every frame message parsing middleware must run before this middleware and return getWalletAddress as part of parsed message.
+ * Every frame message parsing middleware must run before this middleware and return walletAddress() as part of parsed message.
  *
  * This middleware is internal only and must run after globalMiddleware and before perRouteMiddleware. So the message is available.
  */

--- a/packages/frames.js/src/middleware/walletAddressMiddleware.ts
+++ b/packages/frames.js/src/middleware/walletAddressMiddleware.ts
@@ -1,0 +1,56 @@
+import type { FramesContext, FramesMiddleware } from "../core/types";
+
+/**
+ * Every message must implement their own wallet address extraction method.
+ */
+export interface MessageWithWalletAddressImplementation {
+  walletAddress: () => Promise<string | undefined>;
+}
+
+function isContextWithCompaitbleMessage(ctx: unknown): ctx is {
+  message: MessageWithWalletAddressImplementation;
+} {
+  return (
+    !!ctx &&
+    typeof ctx === "object" &&
+    "message" in ctx &&
+    !!ctx.message &&
+    typeof ctx.message === "object" &&
+    "walletAddress" in ctx.message &&
+    typeof ctx.message.walletAddress === "function"
+  );
+}
+
+type WalletAddressFromMessageMiddlewareContext = Pick<
+  FramesContext,
+  "walletAddress"
+>;
+
+/**
+ * This middleware handles wallet address extraction from frame message by providing "walletAddress()" method on context.
+ *
+ * Every frame message parsing middleware must run before this middleware and return getWalletAddress as part of parsed message.
+ *
+ * This middleware is internal only and must run after globalMiddleware and before perRouteMiddleware. So the message is available.
+ */
+export function walletAddressMiddleware(): FramesMiddleware<
+  any,
+  WalletAddressFromMessageMiddlewareContext
+> {
+  return async (ctx, next) => {
+    return next({
+      walletAddress: async () => {
+        if (isContextWithCompaitbleMessage(ctx)) {
+          return ctx.message.walletAddress();
+        }
+
+        // eslint-disable-next-line no-console -- provide info to the developer
+        console.info(
+          "walletAddressFromMessageMiddleware: You called walletAddress() but there is no message or the parsed message does not contain walletAddress() method. Make sure you have run the message parsing middleware before this middleware."
+        );
+
+        return Promise.resolve(undefined);
+      },
+    });
+  };
+}

--- a/packages/frames.js/src/xmtp/index.ts
+++ b/packages/frames.js/src/xmtp/index.ts
@@ -3,11 +3,13 @@ import type {
   XmtpValidationResponse,
 } from "@xmtp/frames-validator";
 import { validateFramesPost } from "@xmtp/frames-validator";
+import type { MessageWithWalletAddressImplementation } from "../middleware/walletAddressMiddleware";
 
 export type XmtpFrameMessageReturnType =
-  XmtpValidationResponse["actionBody"] & {
-    verifiedWalletAddress: string;
-  };
+  MessageWithWalletAddressImplementation &
+    XmtpValidationResponse["actionBody"] & {
+      verifiedWalletAddress: string;
+    };
 
 export function isXmtpFrameActionPayload(
   frameActionPayload: unknown
@@ -30,5 +32,6 @@ export async function getXmtpFrameMessage(
   return {
     ...actionBody,
     verifiedWalletAddress,
+    walletAddress: () => Promise.resolve(verifiedWalletAddress),
   };
 }

--- a/templates/next-starter-with-examples/app/examples/multi-protocol/frames/who-am-i/route.tsx
+++ b/templates/next-starter-with-examples/app/examples/multi-protocol/frames/who-am-i/route.tsx
@@ -1,24 +1,9 @@
 /* eslint-disable react/jsx-key */
 import { Button } from "frames.js/next";
-import { LensClient, production } from "@lens-protocol/client";
 import { frames } from "../frames";
 
 export const POST = frames(async (ctx) => {
-  let walletAddress: string | undefined =
-    // farcaster
-    ctx.message?.requesterCustodyAddress ||
-    // xmtp
-    ctx.message?.verifiedWalletAddress;
-
-  if (ctx.clientProtocol?.id === "lens") {
-    const lensClient = new LensClient({ environment: production });
-
-    const profile = await lensClient.profile.fetch({
-      forProfileId: ctx.message?.profileId,
-    });
-
-    walletAddress = profile?.ownedBy.address;
-  }
+  const walletAddress = await ctx.walletAddress();
 
   return {
     image: (


### PR DESCRIPTION
## Change Summary

This PR adds `walletAddress()` method to context so user can get wallet address associated with frame message.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
