### PR TITLE
fix: cast action message regression

### DIFF
--- a/.changeset/mighty-dingos-exercise.md
+++ b/.changeset/mighty-dingos-exercise.md
@@ -1,0 +1,6 @@
+---
+"@frames.js/debugger": patch
+"@frames.js/render": patch
+---
+
+fix(@frames.js/render): render an inline message for messages returned from cast / composer actions

--- a/docs/pages/reference/render/headless-ui.mdx
+++ b/docs/pages/reference/render/headless-ui.mdx
@@ -11,6 +11,10 @@ The component doesn't have any styles so you must provide your own styles. Only 
 
 Error screen happens if the frame is not renderable.
 
+### Message
+
+Message happens only if the response for cast or composer action returns a message.
+
 ### Root
 
 Root is the main container for the rendered frame.

--- a/docs/pages/reference/render/headless-ui.mdx
+++ b/docs/pages/reference/render/headless-ui.mdx
@@ -13,7 +13,7 @@ Error screen happens if the frame is not renderable.
 
 ### Message
 
-Message happens only if the response for cast or composer action returns a message.
+Message happens only if the response for cast or composer action returns a message. Can be turned off by returning `null` from `Message` component. In combination with `onMessage()` handler you can provide your own message handling experience.
 
 ### Root
 
@@ -41,7 +41,7 @@ Rendered inside `ImageContainer`.
 
 ### Message Tooltip
 
-Rendered inside `ImageContainer`.
+Rendered inside `ImageContainer`. Can be turned off by returning `null` from `MessageTooltip` component. In combination with `onMessage()` handler you can provide your own message handling experience.
 
 #### Text Input Container
 
@@ -95,6 +95,7 @@ By default you can use `className` or `style` to style the components.
     LoadingScreen: {},
     Image: {},
     ImageContainer: {},
+    Message: {},
     MessageTooltip: {},
     Root: {
       // you can use className or style
@@ -123,6 +124,7 @@ By default you can use `style` prop to style the components. Also `className` is
     LoadingScreen: {},
     Image: {},
     ImageContainer: {},
+    Message: {},
     MessageTooltip: {},
     Root: {
       // className: 'flex', native wind
@@ -165,6 +167,9 @@ In case you want to change how components behave you can override them. Each com
     ImageContainer(props, stylingProps) {
       // ...
     },
+    Message(props, stylingProps) {
+      // ...
+    },
     MessageTooltip(props, stylingProps) {
       // ...
     },
@@ -180,3 +185,10 @@ In case you want to change how components behave you can override them. Each com
   }}
 />
 ```
+
+## Error handling and message handling
+
+You can also use `onError()` and `onMessage()` handlers if you want to provide your own error or message handling experience (e.g. show a toast).
+
+- `onError(error: Error): void` is called when there is an error rendering the frame.
+- `onMessage(message: { message: string, status: 'error' | 'message' }): void` is called when the response contains a message.

--- a/packages/debugger/app/components/frame-debugger.tsx
+++ b/packages/debugger/app/components/frame-debugger.tsx
@@ -728,7 +728,8 @@ export const FrameDebugger = React.forwardRef<
                           }}
                         >
                           {getFrameHtmlHead(
-                            "sourceFrame" in currentFrameStackItem.request
+                            "sourceFrame" in currentFrameStackItem.request &&
+                              currentFrameStackItem.request.sourceFrame
                               ? currentFrameStackItem.request.sourceFrame
                               : currentFrameStackItem.frameResult.frame
                           )

--- a/packages/debugger/app/components/frame-debugger.tsx
+++ b/packages/debugger/app/components/frame-debugger.tsx
@@ -261,7 +261,7 @@ const FramesRequestCardContentIcon: React.FC<{
     if (stackItem.type === "info") {
       return <InfoIcon size={20} color="blue" />;
     } else {
-      return <XCircle size={20} color="blue" />;
+      return <XCircle size={20} color="red" />;
     }
   }
 

--- a/packages/debugger/app/components/frame-ui.tsx
+++ b/packages/debugger/app/components/frame-ui.tsx
@@ -1,12 +1,16 @@
 import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/components/ui/use-toast";
 import { cn } from "@/lib/utils";
 import { FrameUI as BaseFrameUI } from "@frames.js/render/ui";
 import { MessageSquareIcon, AlertOctagonIcon, ZapIcon } from "lucide-react";
 import Image from "next/image";
 import React from "react";
 
-type Props = React.ComponentProps<
-  typeof BaseFrameUI<{ className?: string; style?: React.CSSProperties }>
+type Props = Omit<
+  React.ComponentProps<
+    typeof BaseFrameUI<{ className?: string; style?: React.CSSProperties }>
+  >,
+  "onMessage"
 >;
 
 const components: Props["components"] = {
@@ -46,6 +50,8 @@ const components: Props["components"] = {
     );
   },
   Message(props, stylingProps) {
+    // we use onMessage to render a toast instead
+    return null;
     return (
       <div
         {...stylingProps}
@@ -60,6 +66,8 @@ const components: Props["components"] = {
     );
   },
   MessageTooltip(props, stylingProps) {
+    // we use onMessage to render a toast instead
+    return null;
     return (
       <div
         {...stylingProps}
@@ -137,5 +145,19 @@ const theme: Props["theme"] = {
 };
 
 export function FrameUI(props: Props) {
-  return <BaseFrameUI {...props} components={components} theme={theme} />;
+  const { toast } = useToast();
+
+  return (
+    <BaseFrameUI
+      {...props}
+      components={components}
+      theme={theme}
+      onMessage={(message) => {
+        toast({
+          description: message.message,
+          variant: message.status === "error" ? "destructive" : "default",
+        });
+      }}
+    />
+  );
 }

--- a/packages/debugger/app/components/frame-ui.tsx
+++ b/packages/debugger/app/components/frame-ui.tsx
@@ -45,6 +45,20 @@ const components: Props["components"] = {
       </button>
     );
   },
+  Message(props, stylingProps) {
+    return (
+      <div
+        {...stylingProps}
+        className={cn(
+          "p-2 text-sm text-gray-700 border border-gray-300 rounded-md shadow-md bg-white",
+          props.status === "error" && "border-red-500 text-red-500",
+          stylingProps.className
+        )}
+      >
+        {props.message}
+      </div>
+    );
+  },
   MessageTooltip(props, stylingProps) {
     return (
       <div

--- a/packages/render/src/types.ts
+++ b/packages/render/src/types.ts
@@ -234,16 +234,26 @@ export type FramePOSTRequest<
     any,
     any
   > = SignerStateActionContext,
-> = {
-  method: "POST";
-  frameButton: FrameButtonPost | FrameButtonTx;
-  signerStateActionContext: TSignerStateActionContext;
-  isDangerousSkipSigning: boolean;
-  /**
-   * The frame that was the source of the button press.
-   */
-  sourceFrame: Frame;
-};
+> =
+  | {
+      method: "POST";
+      source?: never;
+      frameButton: FrameButtonPost | FrameButtonTx;
+      signerStateActionContext: TSignerStateActionContext;
+      isDangerousSkipSigning: boolean;
+      /**
+       * The frame that was the source of the button press.
+       */
+      sourceFrame: Frame;
+    }
+  | {
+      method: "POST";
+      source: "cast-action" | "composer-action";
+      frameButton: FrameButtonPost | FrameButtonTx;
+      signerStateActionContext: TSignerStateActionContext;
+      isDangerousSkipSigning: boolean;
+      sourceFrame: undefined;
+    };
 
 export type FrameRequest<
   TSignerStateActionContext extends SignerStateActionContext<

--- a/packages/render/src/ui/frame.base.tsx
+++ b/packages/render/src/ui/frame.base.tsx
@@ -97,7 +97,10 @@ export function BaseFrameUI<TStylingProps extends Record<string, unknown>>({
 
   switch (currentFrameStackItem.status) {
     case "requestError": {
-      if ("sourceFrame" in currentFrameStackItem.request) {
+      if (
+        "sourceFrame" in currentFrameStackItem.request &&
+        currentFrameStackItem.request.sourceFrame
+      ) {
         frameUiState = {
           status: "complete",
           frame: currentFrameStackItem.request.sourceFrame,
@@ -116,12 +119,38 @@ export function BaseFrameUI<TStylingProps extends Record<string, unknown>>({
       break;
     }
     case "message":
-    case "doneRedirect": {
+      if (!currentFrameStackItem.request.sourceFrame) {
+        // this happens only for composer or cast actions, in that case just render Message
+        return components.Message(
+          {
+            message: currentFrameStackItem.message,
+            status:
+              currentFrameStackItem.type === "error" ? "error" : "message",
+          },
+          theme?.Message ?? ({} as TStylingProps)
+        );
+      }
+
       frameUiState = {
         status: "complete",
         frame: currentFrameStackItem.request.sourceFrame,
         isImageLoading,
       };
+
+      break;
+    case "doneRedirect": {
+      if (!currentFrameStackItem.request.sourceFrame) {
+        frameUiState = {
+          status: "loading",
+        };
+      } else {
+        frameUiState = {
+          status: "complete",
+          frame: currentFrameStackItem.request.sourceFrame,
+          isImageLoading,
+        };
+      }
+
       break;
     }
     case "done": {

--- a/packages/render/src/ui/index.native.tsx
+++ b/packages/render/src/ui/index.native.tsx
@@ -155,6 +155,13 @@ function createDefaultComponents<TStylingProps extends Record<string, unknown>>(
         createElement(Text, null, "Loading...")
       );
     },
+    Message(props, stylingProps) {
+      return createElement(
+        View,
+        stylingProps,
+        createElement(Text, null, props.message)
+      );
+    },
     MessageTooltip(props, stylingProps) {
       return createElement(
         View,

--- a/packages/render/src/ui/index.tsx
+++ b/packages/render/src/ui/index.tsx
@@ -160,6 +160,16 @@ function createDefaultComponents<TStylingProps extends Record<string, unknown>>(
     LoadingScreen(props, stylingProps) {
       return createElement("div", stylingProps, "Loading...");
     },
+    Message(props, stylingProps) {
+      return createElement(
+        "div",
+        {
+          ...stylingProps,
+          "data-status": props.status,
+        },
+        props.message
+      );
+    },
     MessageTooltip(props, stylingProps) {
       return createElement(
         "div",

--- a/packages/render/src/ui/types.ts
+++ b/packages/render/src/ui/types.ts
@@ -14,6 +14,7 @@ export type FrameUIComponentStylingProps<
   ImageContainer: TStylingProps;
   LoadingScreen: TStylingProps;
   MessageTooltip: TStylingProps;
+  Message: TStylingProps;
   Root: TStylingProps;
   TextInput: TStylingProps;
   TextInputContainer: TStylingProps;
@@ -147,6 +148,13 @@ export type FrameUIComponents<TStylingProps extends Record<string, unknown>> = {
     props: FrameMessageTooltipProps,
     stylingProps: TStylingProps
   ) => ReactElement;
+  /**
+   * Rendered in case there is a message in response to a cast or composer action invokation.
+   */
+  Message: (
+    props: FrameMessageProps,
+    stylingProps: TStylingProps
+  ) => ReactElement;
 };
 
 export type RootContainerElement = {
@@ -240,3 +248,8 @@ export type FrameMessageTooltipProps = {
   message: string;
   status: "error" | "message";
 } & FrameUIStateProps;
+
+export type FrameMessageProps = {
+  message: string;
+  status: "error" | "message";
+};

--- a/packages/render/src/ui/types.ts
+++ b/packages/render/src/ui/types.ts
@@ -147,14 +147,14 @@ export type FrameUIComponents<TStylingProps extends Record<string, unknown>> = {
   MessageTooltip: (
     props: FrameMessageTooltipProps,
     stylingProps: TStylingProps
-  ) => ReactElement;
+  ) => ReactElement | null;
   /**
    * Rendered in case there is a message in response to a cast or composer action invokation.
    */
   Message: (
     props: FrameMessageProps,
     stylingProps: TStylingProps
-  ) => ReactElement;
+  ) => ReactElement | null;
 };
 
 export type RootContainerElement = {
@@ -244,12 +244,11 @@ export type FrameTextInputProps = {
   value?: string;
 } & FrameUIStateProps;
 
-export type FrameMessageTooltipProps = {
-  message: string;
-  status: "error" | "message";
-} & FrameUIStateProps;
-
-export type FrameMessageProps = {
+export type FrameMessage = {
   message: string;
   status: "error" | "message";
 };
+
+export type FrameMessageTooltipProps = FrameMessage & FrameUIStateProps;
+
+export type FrameMessageProps = FrameMessage;

--- a/packages/render/src/use-fetch-frame.ts
+++ b/packages/render/src/use-fetch-frame.ts
@@ -405,6 +405,12 @@ export function useFetchFrame<
     request: FramePOSTRequest<TSignerStateActionContext>,
     shouldClear?: boolean
   ): Promise<void> {
+    if ("source" in request) {
+      throw new Error(
+        "Invalid request, transaction should be invoked only from a Frame. It was probably invoked from cast or composer action."
+      );
+    }
+
     const button = request.frameButton;
     const sourceFrame = request.sourceFrame;
 
@@ -607,12 +613,8 @@ export function useFetchFrame<
         frameButton,
         signerStateActionContext,
         method: "POST",
-        // @todo find a better way how to do this, perhaps pending item should not be create here at all and be created only for relevant requests
-        // actions don't have source frame, fake it
-        sourceFrame: {
-          image: "",
-          version: "vNext",
-        },
+        source: "cast-action",
+        sourceFrame: undefined,
       },
     });
 
@@ -662,11 +664,7 @@ export function useFetchFrame<
         stackAPI.markCastFrameAsDone({ pendingItem, endTime });
 
         await fetchPOSTRequest({
-          // actions don't have source frame, fake it
-          sourceFrame: {
-            image: "",
-            version: "vNext",
-          },
+          sourceFrame: undefined,
           frameButton: {
             action: "post",
             label: "action",
@@ -674,6 +672,7 @@ export function useFetchFrame<
           },
           isDangerousSkipSigning: request.isDangerousSkipSigning,
           method: "POST",
+          source: "cast-action",
           signerStateActionContext: {
             ...request.signerStateActionContext,
             buttonIndex: 1,
@@ -742,10 +741,8 @@ export function useFetchFrame<
         frameButton,
         signerStateActionContext,
         method: "POST",
-        sourceFrame: {
-          image: "",
-          version: "vNext",
-        },
+        source: "composer-action",
+        sourceFrame: undefined,
       },
     });
 


### PR DESCRIPTION
## Change Summary

This PR adds new `Message` component which is rendered in case there is an message and no `sourceFrame`. It also fixes the regression.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
