### PR TITLE
fix(templates): missing dotenv dependency

### DIFF
--- a/.changeset/young-paws-type.md
+++ b/.changeset/young-paws-type.md
@@ -1,0 +1,9 @@
+---
+"template-express": patch
+"template-remix": patch
+"template-hono": patch
+"template-next": patch
+"create-frames": patch
+---
+
+fix(templates): missing dotenv dependency

--- a/templates/express/package.json
+++ b/templates/express/package.json
@@ -18,6 +18,7 @@
     "@vitejs/plugin-react": "^4.2.1",
     "concurrently": "^8.2.2",
     "cross-env": "^7.0.3",
+    "dotenv": "^16.4.5",
     "typescript": "^5.4.5",
     "vite": "^5.1.0",
     "vite-tsconfig-paths": "^4.2.1"

--- a/templates/hono/package.json
+++ b/templates/hono/package.json
@@ -16,6 +16,7 @@
     "@types/react": "^18.2.45",
     "@vitejs/plugin-react": "^4.2.1",
     "concurrently": "^8.2.2",
+    "dotenv": "^16.4.5",
     "typescript": "^5.4.5",
     "vite": "^5.1.0",
     "vite-tsconfig-paths": "^4.2.1"

--- a/templates/next/package.json
+++ b/templates/next/package.json
@@ -15,6 +15,7 @@
     "@types/react-dom": "^18.2.0",
     "@frames.js/debugger": "^0.3.6",
     "concurrently": "^8.2.2",
+    "dotenv": "^16.4.5",
     "is-port-reachable": "^4.0.0",
     "typescript": "^5.4.5"
   },

--- a/templates/remix/package.json
+++ b/templates/remix/package.json
@@ -23,6 +23,7 @@
     "@typescript-eslint/eslint-plugin": "^6.7.4",
     "@typescript-eslint/parser": "^6.7.4",
     "concurrently": "^8.2.2",
+    "dotenv": "^16.4.5",
     "typescript": "^5.4.5",
     "vite": "^5.1.0",
     "vite-tsconfig-paths": "^4.2.1"


### PR DESCRIPTION
## Change Summary

This PR adds missing `dotenv` dependency to some templates.

Closes #463

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
