### PR TITLE
feat: add address of wallet used to create a transaction to message

### DIFF
--- a/.changeset/gold-dots-breathe.md
+++ b/.changeset/gold-dots-breathe.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+feat: address and transactionId in tx frame messages

--- a/.changeset/olive-eagles-push.md
+++ b/.changeset/olive-eagles-push.md
@@ -1,0 +1,6 @@
+---
+"@frames.js/render": minor
+"@frames.js/debugger": patch
+---
+
+feat: onConnectWallet function that complements onTransaction function

--- a/docs/pages/guides/transactions.mdx
+++ b/docs/pages/guides/transactions.mdx
@@ -61,12 +61,12 @@ Use the [Transactions starter](https://github.com/framesjs/frames.js/tree/main/t
 
 The client will include the user's connected wallet address that will be executing the transaction in the frame action payload in the when a frame button with `action="tx"` set is pressed.
 
-The address is available in the context under the key `connectedAddress`.
+The address is available in the context under the key `address`.
 
 Note:
 
 - The address is only available when the user has connected a wallet to the client the frame button pressed is has a `tx` action.
-- `connectedAddress` differs from the `requesterVerifiedAddresses` returned by the [`farcasterHubContext`](/middleware/farcaster-hub-context) middleware.
+- `address` differs from the `requesterVerifiedAddresses` returned by the [`farcasterHubContext`](/middleware/farcaster-hub-context) middleware.
 
 ```tsx [./app/frames/txdata/route.tsx]
 import { frames } from "../frames";
@@ -77,7 +77,7 @@ export const POST = frames(async (ctx) => {
     throw new Error("No message");
   }
 
-  const userAddress = ctx.message.connectedAddress;
+  const userAddress = ctx.message.address;
 
   // Do something with the user's connected address that will be executing the tx
 

--- a/docs/pages/reference/js/getFrameMessage.mdx
+++ b/docs/pages/reference/js/getFrameMessage.mdx
@@ -16,7 +16,7 @@ console.log(frameMessage);
   inputText: '',
   requesterFid: 1689,
   isValid: true,
-  connectedAddress: '0x8d25687829d6b85d9e0020b8c89e3ca24de20a89',
+  address: '0x8d25687829d6b85d9e0020b8c89e3ca24de20a89',
   casterFollowsRequester: false,
   requesterFollowsCaster: false,
   likedCast: false,
@@ -44,7 +44,7 @@ console.log(frameMessage);
   castId: { fid: 1, hash: '0x0000000000000000000000000000000000000000' },
   inputText: '',
   requesterFid: 1689,
-  connectedAddress: '0x8d25687829d6b85d9e0020b8c89e3ca24de20a89'
+  address: '0x8d25687829d6b85d9e0020b8c89e3ca24de20a89'
 }
 **/
 ```
@@ -60,7 +60,7 @@ type FrameActionData = {
   };
   inputText?: string;
   /** Only available in payloads of buttons with action `tx` **/
-  connectedAddress: string;
+  address: string;
 };
 ```
 

--- a/docs/pages/reference/js/types.mdx
+++ b/docs/pages/reference/js/types.mdx
@@ -286,8 +286,10 @@ export type FrameActionDataParsed = {
   };
   inputText?: string;
   state?: string;
-  /** address of the user's connected wallet, only present in transaction data requests */
-  connectedAddress?: string;
+  /**
+   * address of the user's connected wallet used to create the transaction, only present in transaction data requests
+   */
+  address?: `0x${string}`;
   transactionId?: `0x${string}`;
 };
 
@@ -325,5 +327,4 @@ export type ActionMetadata = {
     type: "post";
   };
 };
-
 ```

--- a/docs/pages/reference/render/types.mdx
+++ b/docs/pages/reference/render/types.mdx
@@ -43,7 +43,7 @@ export type UseFrameReturn<
   homeframeUrl: string | null | undefined;
   /** the initial frame. if not specified will fetch it from the url prop */
   frame?: Frame;
-  /** connected wallet address of the user */
+  /** connected wallet address of the user, send to the frame for transaction requests */
   connectedAddress: `0x${string}` | undefined;
   /** a function to handle mint buttons */
   onMint?: (t: OnMintArgs) => void;

--- a/docs/pages/reference/render/use-frame.mdx
+++ b/docs/pages/reference/render/use-frame.mdx
@@ -6,7 +6,9 @@
 
 - Type: `0x${string} | undefined`
 
-The connected wallet address of the user.
+The connected wallet address of the user. The address is part of the frame action payload when a frame button with `action="tx"` is pressed.
+
+If the user presses transaction button without a connected wallet, the `onConnectWallet` function is called.
 
 ### `dangerousSkipSigning`
 
@@ -50,6 +52,12 @@ The url of the homeframe, if null won't load a frame.
 
 The initial frame. if not specified will fetch it from the url prop.
 
+### `onConnectWallet`
+
+- Type: `() => void`
+
+A function to start wallet connecting process. This function is called when a user presses a transaction button without a connected wallet.
+
 ### `onError`
 
 - Type: `(e: Error) => void`
@@ -78,7 +86,7 @@ A function to handle redirect responses from the frame. This happens when you cl
 
 - Type: `OnTransactionFunc`
 
-A function to handle transaction button presses, returns the transaction hash or null.
+A function to handle transaction button presses, returns the transaction hash or null. The function is called when a user presses a transaction button and endpoint specified by `target` returns transaction data.
 
 ### `frameContext`
 

--- a/packages/debugger/app/debugger-page.tsx
+++ b/packages/debugger/app/debugger-page.tsx
@@ -9,6 +9,7 @@ import {
   type OnTransactionFunc,
   type OnSignatureFunc,
   type FrameActionBodyPayload,
+  type OnConnectWalletFunc,
 } from "@frames.js/render";
 import { useFrame } from "@frames.js/render/use-frame";
 import { ConnectButton, useConnectModal } from "@rainbow-me/rainbowkit";
@@ -59,6 +60,7 @@ import type {
   CastActionDefinitionResponse,
   FrameDefinitionResponse,
 } from "./frames/route";
+import { AwaitableController } from "./lib/awaitable-controller";
 
 const FALLBACK_URL =
   process.env.NEXT_PUBLIC_DEBUGGER_DEFAULT_URL || "http://localhost:3000";
@@ -292,17 +294,16 @@ export default function DebuggerPage({
 
   const anonymousFrameContext = {};
 
+  const onConnectWallet: OnConnectWalletFunc = useCallback(async () => {
+    if (!openConnectModal) {
+      throw new Error(`openConnectModal not implemented`);
+    }
+
+    openConnectModal();
+  }, [openConnectModal]);
+
   const onTransaction: OnTransactionFunc = useCallback(
     async ({ transactionData }) => {
-      if (!account.address) {
-        openConnectModal?.();
-        console.info(
-          "Opened connect modal because the account address is not set"
-        );
-
-        return null;
-      }
-
       try {
         const { params, chainId } = transactionData;
         const requestedChainId = parseChainId(chainId);
@@ -354,7 +355,7 @@ export default function DebuggerPage({
         return null;
       }
     },
-    [account.address, currentChainId, config, openConnectModal, toast]
+    [currentChainId, config, toast]
   );
 
   const onSignature: OnSignatureFunc = useCallback(
@@ -433,6 +434,7 @@ export default function DebuggerPage({
     extraButtonRequestPayload: { mockData: mockHubContext },
     onTransaction,
     onSignature,
+    onConnectWallet,
     onError(error) {
       console.error(error);
 

--- a/packages/debugger/app/hooks/use-anonymous-identity.tsx
+++ b/packages/debugger/app/hooks/use-anonymous-identity.tsx
@@ -22,9 +22,10 @@ export function useAnonymousIdentity(): AnonymousSignerInstance {
     },
     async signFrameAction(actionContext) {
       const searchParams = new URLSearchParams({
-        postType: actionContext.transactionId
-          ? "post"
-          : actionContext.frameButton.action,
+        postType:
+          actionContext.type !== "default"
+            ? "post"
+            : actionContext.frameButton.action,
         postUrl: actionContext.target ?? "",
         specification: "openframes",
       });

--- a/packages/debugger/app/hooks/use-lens-identity.tsx
+++ b/packages/debugger/app/hooks/use-lens-identity.tsx
@@ -199,7 +199,8 @@ export function useLensIdentity(): LensSignerInstance {
           inputText: actionContext.inputText || "",
           state: actionContext.state || "",
           buttonIndex: actionContext.buttonIndex,
-          actionResponse: actionContext.transactionId || "",
+          actionResponse:
+            actionContext.type === "tx-post" ? actionContext.transactionId : "",
           profileId: lensSigner.profileId,
           pubId: actionContext.frameContext.pubId || "",
           specVersion: "1.0.0",
@@ -210,9 +211,10 @@ export function useLensIdentity(): LensSignerInstance {
         }
 
         const searchParams = new URLSearchParams({
-          postType: actionContext.transactionId
-            ? "post"
-            : actionContext.frameButton.action,
+          postType:
+            actionContext.type !== "default"
+              ? "post"
+              : actionContext.frameButton.action,
           postUrl:
             actionContext.frameButton.target ?? actionContext.target ?? "",
         });
@@ -237,7 +239,8 @@ export function useLensIdentity(): LensSignerInstance {
           inputText: actionContext.inputText || "",
           state: actionContext.state || "",
           buttonIndex: actionContext.buttonIndex,
-          actionResponse: actionContext.transactionId || "",
+          actionResponse:
+            actionContext.type === "tx-post" ? actionContext.transactionId : "",
           profileId: lensSigner.profileId,
           pubId: actionContext.frameContext.pubId || "",
           specVersion: "1.0.0",
@@ -260,9 +263,10 @@ export function useLensIdentity(): LensSignerInstance {
         });
 
         const searchParams = new URLSearchParams({
-          postType: actionContext.transactionId
-            ? "post"
-            : actionContext.frameButton.action,
+          postType:
+            actionContext.type !== "default"
+              ? "post"
+              : actionContext.frameButton.action,
           postUrl: actionContext.target ?? "",
         });
 

--- a/packages/debugger/app/hooks/use-xmtp-identity.tsx
+++ b/packages/debugger/app/hooks/use-xmtp-identity.tsx
@@ -158,14 +158,19 @@ export function useXmtpIdentity(): XmtpSignerInstance {
         ...(actionContext.frameContext.groupSecret
           ? { groupSecret: actionContext.frameContext.groupSecret }
           : {}),
-        address: actionContext.address,
-        transactionId: actionContext.transactionId,
+        ...(actionContext.type === "tx-data" || actionContext.type === "tx-post"
+          ? { address: actionContext.address }
+          : {}),
+        ...(actionContext.type === "tx-post"
+          ? { transactionId: actionContext.transactionId }
+          : {}),
       });
 
       const searchParams = new URLSearchParams({
-        postType: actionContext.transactionId
-          ? "post"
-          : actionContext.frameButton.action,
+        postType:
+          actionContext.type !== "default"
+            ? "post"
+            : actionContext.frameButton.action,
         postUrl: actionContext.target ?? "",
         specification: "openframes",
       });

--- a/packages/frames.js/src/anonymous/index.ts
+++ b/packages/frames.js/src/anonymous/index.ts
@@ -1,24 +1,14 @@
 import type { MessageWithWalletAddressImplementation } from "../middleware/walletAddressMiddleware";
+import type { OpenFramesActionData } from "../types";
 
 export type AnonymousFrameMessageReturnType =
-  MessageWithWalletAddressImplementation & {
-    buttonIndex: number;
-    state?: string;
-    inputText?: string;
-    unixTimestamp: number;
-    /**
-     * address of the user's connected wallet used to create the transaction,
-     * only present in transaction data requests to endpoint defined by `post_url` and `target` properties
-     */
-    address?: `0x${string}`;
-    /**
-     * available only in tx button's endpoint defined by `post_url` property
-     */
-    transactionId?: `0x${string}`;
-  };
+  MessageWithWalletAddressImplementation &
+    OpenFramesActionData & {
+      unixTimestamp: number;
+    };
 
 export type AnonymousOpenFramesRequest = {
-  clientProtocol: string;
+  clientProtocol: `anonymous@${string}`;
   untrustedData: AnonymousFrameMessageReturnType;
 };
 
@@ -53,6 +43,7 @@ export async function getAnonymousFrameMessage(
     inputText: body.untrustedData.inputText,
     unixTimestamp: body.untrustedData.unixTimestamp,
     address: body.untrustedData.address,
+    connectedAddress: body.untrustedData.address,
     transactionId: body.untrustedData.transactionId,
     walletAddress() {
       return Promise.resolve(body.untrustedData.address || undefined);

--- a/packages/frames.js/src/anonymous/index.ts
+++ b/packages/frames.js/src/anonymous/index.ts
@@ -6,6 +6,15 @@ export type AnonymousFrameMessageReturnType =
     state?: string;
     inputText?: string;
     unixTimestamp: number;
+    /**
+     * address of the user's connected wallet used to create the transaction,
+     * only present in transaction data requests to endpoint defined by `post_url` and `target` properties
+     */
+    address?: `0x${string}`;
+    /**
+     * available only in tx button's endpoint defined by `post_url` property
+     */
+    transactionId?: `0x${string}`;
   };
 
 export type AnonymousOpenFramesRequest = {
@@ -43,8 +52,10 @@ export async function getAnonymousFrameMessage(
     state: body.untrustedData.state,
     inputText: body.untrustedData.inputText,
     unixTimestamp: body.untrustedData.unixTimestamp,
+    address: body.untrustedData.address,
+    transactionId: body.untrustedData.transactionId,
     walletAddress() {
-      return Promise.resolve(undefined);
+      return Promise.resolve(body.untrustedData.address || undefined);
     },
   } as const;
 }

--- a/packages/frames.js/src/core/types.ts
+++ b/packages/frames.js/src/core/types.ts
@@ -1,7 +1,13 @@
 import type { ImageResponse } from "@vercel/og";
-import type { ActionMetadata, ClientProtocolId } from "../types";
+import type {
+  ActionMetadata,
+  ClientProtocolId,
+  OpenFramesActionData,
+} from "../types";
 import type { ImageWorkerOptions } from "../middleware/images-worker/handler";
 import type { Button, ButtonProps } from "./components";
+
+export type { OpenFramesActionData };
 
 export type JsonObject = { [Key in string]: JsonValue } & {
   [Key in string]?: JsonValue | undefined;

--- a/packages/frames.js/src/getFrameMessage.ts
+++ b/packages/frames.js/src/getFrameMessage.ts
@@ -67,19 +67,19 @@ export async function getFrameMessage<T extends GetFrameMessageOptions>(
     inputText: inputTextBytes,
     state: stateBytes,
     transactionId: transactionIdBytes,
+    address: transactionAddressBytes,
   } = decodedMessage.data.frameActionBody;
   const inputText = Buffer.from(inputTextBytes).toString("utf-8");
   const transactionId =
     transactionIdBytes.length > 0 ? bytesToHex(transactionIdBytes) : undefined;
+  const address =
+    transactionAddressBytes.length > 0
+      ? bytesToHex(transactionAddressBytes)
+      : undefined;
   const requesterFid = decodedMessage.data.fid;
   const castId = decodedMessage.data.frameActionBody.castId
     ? normalizeCastId(decodedMessage.data.frameActionBody.castId)
     : undefined;
-
-  const connectedAddress =
-    decodedMessage.data.frameActionBody.address.length > 0
-      ? bytesToHex(decodedMessage.data.frameActionBody.address)
-      : undefined;
 
   const state = Buffer.from(stateBytes).toString("utf-8");
 
@@ -89,7 +89,8 @@ export async function getFrameMessage<T extends GetFrameMessageOptions>(
     inputText,
     requesterFid,
     state,
-    connectedAddress,
+    connectedAddress: address,
+    address,
     transactionId,
   };
 

--- a/packages/frames.js/src/lens/index.ts
+++ b/packages/frames.js/src/lens/index.ts
@@ -6,6 +6,7 @@ import {
 } from "@lens-protocol/client";
 import type { MessageWithWalletAddressImplementation } from "../middleware/walletAddressMiddleware";
 import { InvalidFrameActionPayloadError } from "../core/errors";
+import type { OpenFramesActionData } from "../types";
 
 export type LensFrameRequest = {
   clientProtocol: string;
@@ -40,7 +41,8 @@ type LensFrameVerifiedFields = {
 };
 
 export type LensFrameResponse = MessageWithWalletAddressImplementation &
-  LensFrameVerifiedFields & {
+  LensFrameVerifiedFields &
+  OpenFramesActionData & {
     isValid: boolean;
   };
 

--- a/packages/frames.js/src/middleware/farcaster.test.ts
+++ b/packages/frames.js/src/middleware/farcaster.test.ts
@@ -108,6 +108,7 @@ describe("farcaster middleware", () => {
     expect(next).toHaveBeenCalledWith({
       clientProtocol: { id: "farcaster", version: "vNext" },
       message: {
+        address: "0x89",
         buttonIndex: 1,
         castId: {
           fid: 456,

--- a/packages/frames.js/src/types.ts
+++ b/packages/frames.js/src/types.ts
@@ -268,24 +268,20 @@ export type HubHttpUrlOptions = {
   hubRequestOptions?: RequestInit;
 };
 
-/** Data extracted and parsed from the frame message body */
-export type FrameActionDataParsed = {
+/**
+ * This is a shape of frame action data defined by spec
+ */
+export type OpenFramesActionData = {
+  /**
+   * 1 indexed button index that was pressed by the user
+   */
   buttonIndex: number;
-  requesterFid: number;
-  castId?: {
-    /** the fid of the Farcaster user (unique identifier) that shared the cast that included the frame */
-    fid: number;
-    /** the hash of the cast (unique identifier) that included the frame */
-    hash: `0x${string}`;
-  };
+  /**
+   * An input text entered by the user.
+   * In some implementations it can contain empty string so make sure to check for undefined and empty string as well.
+   */
   inputText?: string;
   state?: string;
-  /**
-   * address of the user's connected wallet, only present in transaction data requests
-   *
-   * @deprecated use `address` instead
-   */
-  connectedAddress?: string;
   /**
    * address of the user's connected wallet used to create the transaction,
    * only present in transaction data requests to endpoint defined by `post_url` and `target` properties
@@ -295,6 +291,23 @@ export type FrameActionDataParsed = {
    * available only in tx button's endpoint defined by `post_url` property
    */
   transactionId?: `0x${string}`;
+  /**
+   * address of the user's connected wallet, only present in transaction data requests
+   *
+   * @deprecated use `address` instead
+   */
+  connectedAddress?: string;
+};
+
+/** Data extracted and parsed from the frame message body */
+export type FrameActionDataParsed = OpenFramesActionData & {
+  requesterFid: number;
+  castId?: {
+    /** the fid of the Farcaster user (unique identifier) that shared the cast that included the frame */
+    fid: number;
+    /** the hash of the cast (unique identifier) that included the frame */
+    hash: `0x${string}`;
+  };
 };
 
 /** Additional context for a frame message which requires communication with a Hub */

--- a/packages/frames.js/src/types.ts
+++ b/packages/frames.js/src/types.ts
@@ -280,8 +280,20 @@ export type FrameActionDataParsed = {
   };
   inputText?: string;
   state?: string;
-  /** address of the user's connected wallet, only present in transaction data requests */
+  /**
+   * address of the user's connected wallet, only present in transaction data requests
+   *
+   * @deprecated use `address` instead
+   */
   connectedAddress?: string;
+  /**
+   * address of the user's connected wallet used to create the transaction,
+   * only present in transaction data requests to endpoint defined by `post_url` and `target` properties
+   */
+  address?: `0x${string}`;
+  /**
+   * available only in tx button's endpoint defined by `post_url` property
+   */
   transactionId?: `0x${string}`;
 };
 

--- a/packages/frames.js/src/xmtp/index.ts
+++ b/packages/frames.js/src/xmtp/index.ts
@@ -4,10 +4,12 @@ import type {
 } from "@xmtp/frames-validator";
 import { validateFramesPost } from "@xmtp/frames-validator";
 import type { MessageWithWalletAddressImplementation } from "../middleware/walletAddressMiddleware";
+import type { OpenFramesActionData } from "../types";
 
 export type XmtpFrameMessageReturnType =
   MessageWithWalletAddressImplementation &
-    XmtpValidationResponse["actionBody"] & {
+    Omit<XmtpValidationResponse["actionBody"], "address" | "transactionId"> &
+    OpenFramesActionData & {
       verifiedWalletAddress: string;
     };
 
@@ -29,8 +31,17 @@ export async function getXmtpFrameMessage(
   const { actionBody, verifiedWalletAddress } =
     await validateFramesPost(frameActionPayload);
 
+  const address = (actionBody.address || "").startsWith("0x")
+    ? (actionBody.address as `0x${string}`)
+    : undefined;
+
   return {
     ...actionBody,
+    address,
+    connectedAddress: address,
+    transactionId: (actionBody.transactionId || "").startsWith("0x")
+      ? (actionBody.transactionId as `0x${string}`)
+      : undefined,
     verifiedWalletAddress,
     walletAddress: () => Promise.resolve(verifiedWalletAddress),
   };

--- a/packages/render/src/use-frame-stack.ts
+++ b/packages/render/src/use-frame-stack.ts
@@ -14,6 +14,7 @@ import type {
   FrameStackPostPending,
   GetFrameResult,
   SignedFrameAction,
+  SignerStateActionContext,
 } from "./types";
 
 function computeDurationInSeconds(start: Date, end: Date): number {
@@ -124,16 +125,20 @@ export type FrameStackAPI = {
   createGetPendingItem: (arg: {
     request: FrameGETRequest;
   }) => FrameStackGetPending;
-  createPostPendingItem: (arg: {
+  createPostPendingItem: <
+    TSignerStateActionContext extends SignerStateActionContext<any, any>,
+  >(arg: {
     action: SignedFrameAction;
-    request: FramePOSTRequest;
+    request: FramePOSTRequest<TSignerStateActionContext>;
   }) => FrameStackPostPending;
   /**
    * Creates a pending item without dispatching it
    */
-  createCastOrComposerActionPendingItem: (arg: {
+  createCastOrComposerActionPendingItem: <
+    TSignerStateActionContext extends SignerStateActionContext<any, any>,
+  >(arg: {
     action: SignedFrameAction;
-    request: FramePOSTRequest;
+    request: FramePOSTRequest<TSignerStateActionContext>;
   }) => FrameStackPostPending;
   markCastMessageAsDone: (arg: {
     pendingItem: FrameStackPostPending;

--- a/templates/next-starter-with-examples/app/examples/transactions/frames/frames.ts
+++ b/templates/next-starter-with-examples/app/examples/transactions/frames/frames.ts
@@ -1,8 +1,48 @@
 import { createFrames } from "frames.js/next";
 import { appURL } from "../../../utils";
+import { openframes } from "frames.js/middleware";
+import { getXmtpFrameMessage, isXmtpFrameActionPayload } from "frames.js/xmtp";
+import { getLensFrameMessage, isLensFrameActionPayload } from "frames.js/lens";
 
 export const frames = createFrames({
   basePath: "/examples/transactions/frames",
   baseUrl: appURL(),
   debug: process.env.NODE_ENV === "development",
+  middleware: [
+    openframes({
+      clientProtocol: {
+        id: "xmtp",
+        version: "2024-02-09",
+      },
+      handler: {
+        isValidPayload: (body) => isXmtpFrameActionPayload(body),
+        getFrameMessage: async (body) => {
+          if (!isXmtpFrameActionPayload(body)) {
+            return undefined;
+          }
+          const result = await getXmtpFrameMessage(body);
+
+          return { ...result };
+        },
+      },
+    }),
+    openframes({
+      clientProtocol: {
+        id: "lens",
+        version: "1.0.0",
+      },
+      handler: {
+        isValidPayload: (body) => isLensFrameActionPayload(body),
+        getFrameMessage: async (body) => {
+          if (!isLensFrameActionPayload(body)) {
+            return undefined;
+          }
+          const result = await getLensFrameMessage(body);
+
+          return { ...result };
+        },
+      },
+    }),
+    openframes(), // anonymous
+  ],
 });

--- a/templates/next-starter-with-examples/app/examples/transactions/frames/route.tsx
+++ b/templates/next-starter-with-examples/app/examples/transactions/frames/route.tsx
@@ -7,7 +7,9 @@ const handleRequest = frames(async (ctx) => {
     return {
       image: (
         <div tw="bg-purple-800 text-white w-full h-full justify-center items-center flex">
-          Transaction submitted! {ctx.message.transactionId}
+          {ctx.message.address
+            ? `Transaction ${ctx.message.transactionId} from ${ctx.message.address} submitted!`
+            : `Transaction ${ctx.message.transactionId} submitted!`}
         </div>
       ),
       imageOptions: {
@@ -27,7 +29,7 @@ const handleRequest = frames(async (ctx) => {
   return {
     image: (
       <div tw="bg-purple-800 text-white w-full h-full justify-center items-center">
-        Rent farcaster storage
+        Rent farcaster storage or send to yourself
       </div>
     ),
     imageOptions: {
@@ -36,6 +38,9 @@ const handleRequest = frames(async (ctx) => {
     buttons: [
       <Button action="tx" target="/txdata" post_url="/">
         Buy a unit
+      </Button>,
+      <Button action="tx" target="/txdata-self" post_url="/">
+        Send to yourself
       </Button>,
     ],
   };

--- a/templates/next-starter-with-examples/app/examples/transactions/frames/txdata-self/route.ts
+++ b/templates/next-starter-with-examples/app/examples/transactions/frames/txdata-self/route.ts
@@ -1,0 +1,21 @@
+import { frames } from "../frames";
+import { transaction } from "frames.js/core";
+
+export const POST = frames(async (ctx) => {
+  if (!ctx?.message) {
+    throw new Error("Invalid frame message");
+  }
+
+  if (!ctx.message.address) {
+    throw new Error("Address is required, make sure the protocol supports it.");
+  }
+
+  return transaction({
+    chainId: "eip155:10", // OP Mainnet 10
+    method: "eth_sendTransaction",
+    params: {
+      abi: [],
+      to: ctx.message.address,
+    },
+  });
+});


### PR DESCRIPTION
## Change Summary

This PR adds `address` property to `ctx.message` that is set to wallet's address used to create a transaction when user presses `tx` button. The `address` is availale in both endpoints defined by `post_url` and `target` props.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
