### PR TITLE
fix: use initial state when value is not stored in storage or is removed from it

### DIFF
--- a/.changeset/shy-peaches-accept.md
+++ b/.changeset/shy-peaches-accept.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/render": patch
+---
+
+fix: use initial state when value is not stored in storage or is removed from it


### PR DESCRIPTION
## Change Summary

This PR fixes an issue when initial value is first set but then when async storage resolves with undefined it was removed.

Now the initial value works fine, each time there is an undefined value (storage doesn't contain a value or the value has been removed), we use initial value.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
