### PR TITLE
fix: pass initial state to setter if there is no value in storage

### DIFF
--- a/.changeset/light-donuts-mix.md
+++ b/.changeset/light-donuts-mix.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/render": patch
+---
+
+fix: pass initial state to setter if the storage value is undefined

--- a/packages/render/src/hooks/use-storage.ts
+++ b/packages/render/src/hooks/use-storage.ts
@@ -103,10 +103,15 @@ export function useStorage<
 
   const setState: Setter<TValue | undefined> = useCallback(
     async (setter) => {
-      await storageRef.current.set<TValue | undefined>(
-        key,
-        typeof setter === "function" ? setter : () => setter
-      );
+      await storageRef.current.set<TValue | undefined>(key, (currentState) => {
+        if (typeof setter !== "function") {
+          return setter;
+        }
+
+        return setter(
+          currentState === undefined ? initialValueRef.current : currentState
+        );
+      });
     },
     [key]
   );


### PR DESCRIPTION
## Change Summary

This PR fixes passing setting a value on storage with setter function if there is no value in storage by providing an initial value.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
