### PR TITLE
feat: return signer approval when creating signer on farcaster

### DIFF
--- a/.changeset/tough-days-breathe.md
+++ b/.changeset/tough-days-breathe.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/render": patch
+---
+
+feat: return signer approval when creating signer on farcaster

--- a/packages/debugger/app/components/farcaster-signer-config.tsx
+++ b/packages/debugger/app/components/farcaster-signer-config.tsx
@@ -45,7 +45,7 @@ import type { FarcasterSigner } from "@frames.js/render/identity/farcaster";
 type FarcasterSignerConfigProps = {
   farcasterUser: FarcasterSigner | null;
   loading: boolean;
-  startFarcasterSignerProcess: () => Promise<void>;
+  startFarcasterSignerProcess: () => Promise<any>;
   impersonateUser: (fid: number) => Promise<void>;
   logout: () => void;
   removeIdentity: () => void;

--- a/packages/render/src/identity/farcaster/types.ts
+++ b/packages/render/src/identity/farcaster/types.ts
@@ -34,3 +34,8 @@ export type FarcasterSigner =
   | FarcasterSignerApproved
   | FarcasterSignerImpersonating
   | FarcasterSignerPendingApproval;
+
+export type FarcasterCreateSignerResult = {
+  token: string;
+  signerApprovalUrl: string;
+};

--- a/packages/render/src/identity/farcaster/use-farcaster-multi-identity.tsx
+++ b/packages/render/src/identity/farcaster/use-farcaster-multi-identity.tsx
@@ -15,6 +15,7 @@ import { WebStorage } from "../storage";
 import { useStorage } from "../../hooks/use-storage";
 import { IdentityPoller } from "./identity-poller";
 import type {
+  FarcasterCreateSignerResult,
   FarcasterSignedKeyRequest,
   FarcasterSigner,
   FarcasterSignerApproved,
@@ -198,7 +199,7 @@ type UseFarcasterMultiIdentityOptions = {
 
 export type FarcasterMultiSignerInstance =
   FarcasterSignerState<FarcasterSigner | null> & {
-    createSigner: () => Promise<void>;
+    createSigner: () => Promise<FarcasterCreateSignerResult>;
     impersonateUser: (fid: number) => Promise<void>;
     removeIdentity: () => Promise<void>;
     identities: FarcasterSigner[];
@@ -268,97 +269,109 @@ export function useFarcasterMultiIdentity({
   const generateUserIdRef = useRef(generateUserId);
   generateUserIdRef.current = generateUserId;
 
-  const createFarcasterSigner = useCallback(async () => {
-    try {
-      const keypair = await createKeypairEDDSA();
-      const keypairString = convertKeypairToHex(keypair);
-      const authorizationResponse = await fetch(
-        // real signer or local one are handled by local route so we don't need to expose anything to client side bundle
-        signerUrl,
-        {
-          method: "POST",
-          body: JSON.stringify({
-            publicKey: keypairString.publicKey,
-          }),
-        }
-      );
-      const authorizationBody = (await authorizationResponse.json()) as
-        | {
-            signature: string;
-            requestFid: string;
-            deadline: number;
-            requestSigner: string;
+  const createFarcasterSigner =
+    useCallback(async (): Promise<FarcasterCreateSignerResult> => {
+      try {
+        const keypair = await createKeypairEDDSA();
+        const keypairString = convertKeypairToHex(keypair);
+        const authorizationResponse = await fetch(
+          // real signer or local one are handled by local route so we don't need to expose anything to client side bundle
+          signerUrl,
+          {
+            method: "POST",
+            body: JSON.stringify({
+              publicKey: keypairString.publicKey,
+            }),
           }
-        | { code: number; message: string };
-      if (authorizationResponse.status === 200) {
-        const { signature, requestFid, deadline, requestSigner } =
-          authorizationBody as {
-            signature: string;
-            requestFid: string;
-            deadline: number;
-            requestSigner: string;
+        );
+        const authorizationBody = (await authorizationResponse.json()) as
+          | {
+              signature: string;
+              requestFid: string;
+              deadline: number;
+              requestSigner: string;
+            }
+          | { code: number; message: string };
+
+        if (authorizationResponse.status === 200) {
+          const { signature, requestFid, deadline, requestSigner } =
+            authorizationBody as {
+              signature: string;
+              requestFid: string;
+              deadline: number;
+              requestSigner: string;
+            };
+
+          const {
+            result: { signedKeyRequest },
+          } = (await (
+            await fetch(`https://api.warpcast.com/v2/signed-key-requests`, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                key: keypairString.publicKey,
+                signature,
+                requestFid,
+                deadline,
+              }),
+            })
+          ).json()) as {
+            result: {
+              signedKeyRequest: { token: string; deeplinkUrl: string };
+            };
           };
 
-        const {
-          result: { signedKeyRequest },
-        } = (await (
-          await fetch(`https://api.warpcast.com/v2/signed-key-requests`, {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              key: keypairString.publicKey,
-              signature,
-              requestFid,
-              deadline,
-            }),
-          })
-        ).json()) as {
-          result: { signedKeyRequest: { token: string; deeplinkUrl: string } };
-        };
+          // this deeplink works only on iOS, make sure it works on android too by using app link
+          const deepLinkUrl = new URL(signedKeyRequest.deeplinkUrl);
+          const signedKeyRequestToken = deepLinkUrl.searchParams.get("token");
+          const signerApprovalUrl = new URL(
+            "https://client.warpcast.com/deeplinks/signed-key-request"
+          );
 
-        // this deeplink works only on iOS, make sure it works on android too by using app link
-        const deepLinkUrl = new URL(signedKeyRequest.deeplinkUrl);
-        const signedKeyRequestToken = deepLinkUrl.searchParams.get("token");
-        const signerApprovalUrl = new URL(
-          "https://client.warpcast.com/deeplinks/signed-key-request"
-        );
-
-        if (!signedKeyRequestToken) {
-          throw new Error("No token found in the deep link URL");
-        }
-
-        signerApprovalUrl.searchParams.set("token", signedKeyRequestToken);
-
-        await setState((currentState) => {
-          const newState = identityReducer(currentState, {
-            type: "LOGIN_START",
-            id: generateUserIdRef.current(),
-            publicKey: keypairString.publicKey,
-            privateKey: keypairString.privateKey,
-            deadline,
-            token: signedKeyRequestToken,
-            signerApprovalUrl: signerApprovalUrl.toString(),
-            requestFid: parseInt(requestFid, 10),
-            requestSigner,
-            signature,
-          });
-
-          if (newState.activeIdentity?.status === "pending_approval") {
-            onLogInStartRef.current?.(newState.activeIdentity);
+          if (!signedKeyRequestToken) {
+            throw new Error("No token found in the deep link URL");
           }
 
-          return newState;
-        });
-      } else if ("message" in authorizationBody) {
-        throw new Error(authorizationBody.message);
+          signerApprovalUrl.searchParams.set("token", signedKeyRequestToken);
+
+          await setState((currentState) => {
+            const newState = identityReducer(currentState, {
+              type: "LOGIN_START",
+              id: generateUserIdRef.current(),
+              publicKey: keypairString.publicKey,
+              privateKey: keypairString.privateKey,
+              deadline,
+              token: signedKeyRequestToken,
+              signerApprovalUrl: signerApprovalUrl.toString(),
+              requestFid: parseInt(requestFid, 10),
+              requestSigner,
+              signature,
+            });
+
+            if (newState.activeIdentity?.status === "pending_approval") {
+              onLogInStartRef.current?.(newState.activeIdentity);
+            }
+
+            return newState;
+          });
+
+          return {
+            token: signedKeyRequestToken,
+            signerApprovalUrl: signerApprovalUrl.toString(),
+          };
+        } else if ("message" in authorizationBody) {
+          throw new Error(authorizationBody.message);
+        }
+
+        throw new Error("Could not request signer approval.");
+      } catch (error) {
+        // eslint-disable-next-line no-console -- provide feedback
+        console.error("@frames.js/render: API Call failed", error);
+        throw error;
       }
-    } catch (error) {
-      // eslint-disable-next-line no-console -- provide feedback
-      console.error("@frames.js/render: API Call failed", error);
-    }
-  }, [setState, signerUrl]);
+    }, [setState, signerUrl]);
 
   const impersonateUser = useCallback(
     async (fid: number) => {
@@ -398,8 +411,10 @@ export function useFarcasterMultiIdentity({
 
   const createSigner = useCallback(async () => {
     setIsLoading(true);
-    await createFarcasterSigner();
+    const result = await createFarcasterSigner();
     setIsLoading(false);
+
+    return result;
   }, [createFarcasterSigner]);
 
   const logout = useCallback(async () => {


### PR DESCRIPTION
## Change Summary

This PR adds a result to `createSigner()` so we don't need to wait for signer to be updated in state and react to that in effect. This is more convenient, especially when you need to react to that result.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
