### PR TITLE
fix(frames.js): expose frame url in ctx.message

### DIFF
--- a/.changeset/flat-dragons-tan.md
+++ b/.changeset/flat-dragons-tan.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix(frames.js): expose frame url in ctx.message

--- a/packages/frames.js/src/anonymous/index.ts
+++ b/packages/frames.js/src/anonymous/index.ts
@@ -39,6 +39,7 @@ export async function getAnonymousFrameMessage(
   }
 
   return {
+    url: body.untrustedData.url,
     buttonIndex: body.untrustedData.buttonIndex,
     state: body.untrustedData.state,
     inputText: body.untrustedData.inputText,

--- a/packages/frames.js/src/getFrameMessage.ts
+++ b/packages/frames.js/src/getFrameMessage.ts
@@ -63,12 +63,14 @@ export async function getFrameMessage<T extends GetFrameMessageOptions>(
   assertIsFarcasterMessage(decodedMessage);
 
   const {
+    url: urlBytes,
     buttonIndex,
     inputText: inputTextBytes,
     state: stateBytes,
     transactionId: transactionIdBytes,
     address: transactionAddressBytes,
   } = decodedMessage.data.frameActionBody;
+  const url = Buffer.from(urlBytes).toString("utf-8");
   const inputText = Buffer.from(inputTextBytes).toString("utf-8");
   const transactionId =
     transactionIdBytes.length > 0 ? bytesToHex(transactionIdBytes) : undefined;
@@ -84,6 +86,7 @@ export async function getFrameMessage<T extends GetFrameMessageOptions>(
   const state = Buffer.from(stateBytes).toString("utf-8");
 
   const parsedData: FrameActionDataParsed = {
+    url,
     buttonIndex,
     castId,
     inputText,

--- a/packages/frames.js/src/middleware/farcaster.test.ts
+++ b/packages/frames.js/src/middleware/farcaster.test.ts
@@ -20,6 +20,7 @@ describe("farcaster middleware", () => {
                 data: {
                   fid: 123,
                   frameActionBody: {
+                    url: Buffer.from("https://example.com"),
                     castId: {
                       fid: 456,
                     },
@@ -108,6 +109,7 @@ describe("farcaster middleware", () => {
     expect(next).toHaveBeenCalledWith({
       clientProtocol: { id: "farcaster", version: "vNext" },
       message: {
+        url: "https://example.com",
         address: "0x89",
         buttonIndex: 1,
         castId: {

--- a/packages/frames.js/src/types.ts
+++ b/packages/frames.js/src/types.ts
@@ -273,6 +273,10 @@ export type HubHttpUrlOptions = {
  */
 export type OpenFramesActionData = {
   /**
+   * The URL of the frame that the action was triggered from
+   */
+  url: string;
+  /**
    * 1 indexed button index that was pressed by the user
    */
   buttonIndex: number;

--- a/packages/frames.js/src/xmtp/index.ts
+++ b/packages/frames.js/src/xmtp/index.ts
@@ -37,6 +37,7 @@ export async function getXmtpFrameMessage(
 
   return {
     ...actionBody,
+    url: actionBody.frameUrl,
     address,
     connectedAddress: address,
     transactionId: (actionBody.transactionId || "").startsWith("0x")


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Updates `getFrameMessage` to include the frame url in the return value. By extension this exposes the frame URL in the `ctx.message` object.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
