### PR TITLE
chore: recommend using latest cli

### DIFF
--- a/docs/pages/cli/creating-a-project-from-template.mdx
+++ b/docs/pages/cli/creating-a-project-from-template.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Creating a Project from a Template'
-description: 'A guide to demonstrate how to create a project from a template with Frames.js'
+title: "Creating a Project from a Template"
+description: "A guide to demonstrate how to create a project from a template with Frames.js"
 ---
 
 # Creating a Project from a Template
@@ -14,15 +14,15 @@ To create a new project from a template interactively, run the following command
 :::code-group
 
 ```bash [npm]
-npm init frames
+npm init frames@latest
 ```
 
 ```bash [yarn]
-yarn create frames
+yarn create frames@latest
 ```
 
 ```bash [pnpm]
-pnpm create frames
+pnpm create frames@latest
 ```
 
 :::

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -38,15 +38,15 @@ Run one of the commands below based on your preferred package manager and then f
 :::code-group
 
 ```bash [npm]
-npm init frames
+npm init frames@latest
 ```
 
 ```bash [yarn]
-yarn create frames
+yarn create frames@latest
 ```
 
 ```bash [pnpm]
-pnpm create frames
+pnpm create frames@latest
 ```
 
 :::

--- a/packages/create-frames/README.md
+++ b/packages/create-frames/README.md
@@ -7,19 +7,19 @@ Create a new Frames.js app with a single command using predefined templates.
 ### Using npm
 
 ```sh
-npm init frames
+npm init frames@latest
 ```
 
 ### Using yarn
 
 ```sh
-yarn create frames
+yarn create frames@latest
 ```
 
 ### Using pnpm
 
 ```sh
-pnpm create frames
+pnpm create frames@latest
 ```
 
 ## Installing globally (optional) and running from terminal


### PR DESCRIPTION
## Change Summary

A common issue is that builders are running an out of date CLI to create their frames. This ensures they use the latest

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
