### PR TITLE
fix: update docs to remove is frame valid

### DIFF
--- a/docs/pages/reference/render/use-frame.mdx
+++ b/docs/pages/reference/render/use-frame.mdx
@@ -158,12 +158,6 @@ Sets the input text.
 
 Handles a button press on given Frame.
 
-### `isFrameValid`
-
-- Type: `boolean | undefined`
-
-Whether the frame at the top of the stack has any frame validation errors. Undefined when the frame is not loaded or set.
-
 ### `frameValidationErrors`
 
 - Type: `Record<string, string[]> | undefined | null`


### PR DESCRIPTION
## Change Summary

removes deprecated method `isFrameValid` from docs

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
