### PR TITLE
feat: pass down previous frame to loading screen on frame ui

### DIFF
--- a/.changeset/nine-toes-fetch.md
+++ b/.changeset/nine-toes-fetch.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/render": patch
+---
+
+adds previous frame props to LoadingScreen in FrameUI

--- a/packages/render/src/ui/frame.base.tsx
+++ b/packages/render/src/ui/frame.base.tsx
@@ -79,6 +79,8 @@ export function BaseFrameUI<TStylingProps extends Record<string, unknown>>({
   const rootRef = useRef<RootContainerElement>(null);
   const rootDimensionsRef = useRef<RootContainerDimensions | undefined>();
   const previousFrameAspectRatioRef = useRef<"1:1" | "1.91:1" | undefined>();
+  const previousFrameButtonsRef = useRef<number | null>(null);
+  const previousFrameTextInputRef = useRef<boolean | null>(null);
 
   const onImageLoadEnd = useCallback(() => {
     setIsImageLoading(false);
@@ -242,6 +244,11 @@ export function BaseFrameUI<TStylingProps extends Record<string, unknown>>({
         ? components.LoadingScreen(
             {
               frameState: frameUiState,
+              previousFrame: {
+                aspectRatio: previousFrameAspectRatioRef.current ?? null,
+                buttons: previousFrameButtonsRef.current ?? 0,
+                textInput: previousFrameTextInputRef.current ?? false,
+              },
               dimensions: rootDimensionsRef.current ?? null,
             },
             theme?.LoadingScreen || ({} as TStylingProps)
@@ -272,6 +279,9 @@ export function BaseFrameUI<TStylingProps extends Record<string, unknown>>({
                         previousFrameAspectRatioRef.current =
                           frameUiState.frame.imageAspectRatio ?? "1.91:1";
 
+                        // track number of buttons
+                        previousFrameButtonsRef.current = frameUiState.frame.buttons?.length ?? 0;
+                        previousFrameTextInputRef.current = frameUiState.frame.inputText !== undefined;
                         Promise.resolve(
                           frameState.onButtonPress(
                             // @todo change the type onButtonPress to accept partial frame as well because that can happen if partial frames are enabled

--- a/packages/render/src/ui/frame.base.tsx
+++ b/packages/render/src/ui/frame.base.tsx
@@ -14,6 +14,7 @@ import type {
   FrameUIState,
   RootContainerDimensions,
   RootContainerElement,
+  PartialFrame,
 } from "./types";
 import {
   getErrorMessageFromFramesStackItem,
@@ -79,8 +80,7 @@ export function BaseFrameUI<TStylingProps extends Record<string, unknown>>({
   const rootRef = useRef<RootContainerElement>(null);
   const rootDimensionsRef = useRef<RootContainerDimensions | undefined>();
   const previousFrameAspectRatioRef = useRef<"1:1" | "1.91:1" | undefined>();
-  const previousFrameButtonsRef = useRef<number | null>(null);
-  const previousFrameTextInputRef = useRef<boolean | null>(null);
+  const previousFrameRef = useRef<Frame |PartialFrame | null>(null);
 
   const onImageLoadEnd = useCallback(() => {
     setIsImageLoading(false);
@@ -244,11 +244,7 @@ export function BaseFrameUI<TStylingProps extends Record<string, unknown>>({
         ? components.LoadingScreen(
             {
               frameState: frameUiState,
-              previousFrame: {
-                aspectRatio: previousFrameAspectRatioRef.current ?? null,
-                buttons: previousFrameButtonsRef.current ?? 0,
-                textInput: previousFrameTextInputRef.current ?? false,
-              },
+              previousFrame: previousFrameRef.current,
               dimensions: rootDimensionsRef.current ?? null,
             },
             theme?.LoadingScreen || ({} as TStylingProps)
@@ -279,9 +275,8 @@ export function BaseFrameUI<TStylingProps extends Record<string, unknown>>({
                         previousFrameAspectRatioRef.current =
                           frameUiState.frame.imageAspectRatio ?? "1.91:1";
 
-                        // track number of buttons
-                        previousFrameButtonsRef.current = frameUiState.frame.buttons?.length ?? 0;
-                        previousFrameTextInputRef.current = frameUiState.frame.inputText !== undefined;
+                        // track frame
+                        previousFrameRef.current = frameUiState.frame;
                         Promise.resolve(
                           frameState.onButtonPress(
                             // @todo change the type onButtonPress to accept partial frame as well because that can happen if partial frames are enabled

--- a/packages/render/src/ui/types.ts
+++ b/packages/render/src/ui/types.ts
@@ -75,11 +75,7 @@ export type FrameImageContainerProps = {
 
 export type FrameLoadingScreenProps = FrameUIStateProps & {
   dimensions: RootContainerDimensions | null;
-  previousFrame?: { 
-    aspectRatio?: "1:1" | "1.91:1" | null;
-    buttons?: number;
-    textInput?: boolean;
-  };
+  previousFrame: Frame | PartialFrame | null;
 };
 
 export type FrameButtonContainerProps = {

--- a/packages/render/src/ui/types.ts
+++ b/packages/render/src/ui/types.ts
@@ -75,6 +75,11 @@ export type FrameImageContainerProps = {
 
 export type FrameLoadingScreenProps = FrameUIStateProps & {
   dimensions: RootContainerDimensions | null;
+  previousFrame?: { 
+    aspectRatio?: "1:1" | "1.91:1" | null;
+    buttons?: number;
+    textInput?: boolean;
+  };
 };
 
 export type FrameButtonContainerProps = {


### PR DESCRIPTION
## Change Summary

 - [x] Passes down prevFrame as props to LoadingScreen on FrameUI.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)

