### PR TITLE
feat: support for cast action postUrl property

### DIFF
--- a/.changeset/tiny-carrots-shake.md
+++ b/.changeset/tiny-carrots-shake.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+feat: support for cast action postUrl property

--- a/packages/frames.js/src/core/types.ts
+++ b/packages/frames.js/src/core/types.ts
@@ -431,6 +431,8 @@ export type CastActionResponse = {
   /** The action type. (Same type options as frame buttons). Only post is accepted in V1. */
   action: {
     type: "post";
+    /** Optional action handler URL. If not provided, clients will POST to the same URL as the action metadata route. */
+    postUrl?: string;
   };
 };
 

--- a/packages/render/src/use-fetch-frame.ts
+++ b/packages/render/src/use-fetch-frame.ts
@@ -607,7 +607,7 @@ export function useFetchFrame<
     const frameButton: FrameButtonPost = {
       action: "post",
       label: request.action.name,
-      target: request.action.url,
+      target: request.action.action.postUrl || request.action.url,
     };
     const signerStateActionContext: SignerStateDefaultActionContext<
       TSignerStorageType,


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Fixes https://linear.app/modprotocol/issue/FRA-395/missing-actionposturl-on-cast-action-definition

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
