### PR TITLE
fix(debugger): avoid infinite rendering cycles when using console.log

### DIFF
--- a/.changeset/pretty-mangos-shop.md
+++ b/.changeset/pretty-mangos-shop.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/debugger": patch
+---
+
+fix(debugger): avoid infinite rendering cycles when using console.log

--- a/packages/debugger/app/debugger-page.tsx
+++ b/packages/debugger/app/debugger-page.tsx
@@ -95,7 +95,7 @@ export default function DebuggerPage({
 }): JSX.Element {
   const debuggerRef = useRef<FrameDebuggerRef>(null);
   const actionDebuggerRef = useRef<ActionDebuggerRef>(null);
-  const { logs, clear: clearLogs } = useDebuggerConsole();
+  const debuggerConsole = useDebuggerConsole();
   const { toast } = useToast();
   const urlInputRef = useRef<HTMLInputElement>(null);
   const selectProtocolButtonRef = useRef<HTMLButtonElement>(null);
@@ -250,9 +250,9 @@ export default function DebuggerPage({
       return;
     }
 
-    clearLogs();
+    debuggerConsole.clear();
     refreshUrl(url);
-  }, [url, protocolConfiguration, refreshUrl, toast, clearLogs]);
+  }, [url, protocolConfiguration, refreshUrl, toast, debuggerConsole]);
 
   const farcasterSignerState = useFarcasterMultiIdentity({
     onMissingIdentity() {
@@ -646,7 +646,7 @@ export default function DebuggerPage({
   ]);
 
   return (
-    <DebuggerConsoleContextProvider value={logs}>
+    <DebuggerConsoleContextProvider value={debuggerConsole}>
       <div className="bg-slate-50 min-h-lvh grid grid-rows-[auto_1fr]">
         <div className="flex flex-row gap-4 border-b p-2 px-4 items-center h-full bg-white">
           <svg


### PR DESCRIPTION
## Change Summary

This PR fixes an issue when console.log() could cause infinite render cycle.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
