### PR TITLE
feat: expose full frameState in render UI components

### DIFF
--- a/.changeset/dry-bulldogs-jog.md
+++ b/.changeset/dry-bulldogs-jog.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/render": patch
+---
+
+feat: expose full frameState in render UI components

--- a/packages/render/src/ui/types.ts
+++ b/packages/render/src/ui/types.ts
@@ -1,11 +1,12 @@
 import type { Frame, FrameButton } from "frames.js";
 import type { createElement, ReactElement } from "react";
+import type { FrameState } from "../types";
 
 /**
  * Allows to override styling props on all component of the Frame UI
  */
 export type FrameUIComponentStylingProps<
-  TStylingProps extends Record<string, unknown>,
+  TStylingProps extends Record<string, unknown>
 > = {
   Button: TStylingProps;
   ButtonsContainer: TStylingProps;
@@ -29,11 +30,12 @@ export type PartialFrame = Omit<Partial<Frame>, RequiredFrameProperties> &
   Required<Pick<Frame, RequiredFrameProperties>>;
 
 export type FrameUIState =
-  | { status: "loading"; id: number }
+  | { status: "loading"; id: number; frameState: FrameState }
   | {
       id: number;
       status: "partial";
       frame: PartialFrame;
+      frameState: FrameState;
       debugImage?: string;
       isImageLoading: boolean;
     }
@@ -41,6 +43,7 @@ export type FrameUIState =
       id: number;
       status: "complete";
       frame: Frame;
+      frameState: FrameState;
       debugImage?: string;
       isImageLoading: boolean;
     };
@@ -75,7 +78,6 @@ export type FrameImageContainerProps = {
 
 export type FrameLoadingScreenProps = FrameUIStateProps & {
   dimensions: RootContainerDimensions | null;
-  previousFrame: Frame | PartialFrame | null;
 };
 
 export type FrameButtonContainerProps = {


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->

Exposes the full frame state in UI components in the `render` package.

Example use case: reordering buttons without modifying the frame state (apply the patch and view `http://localhost:3010/?url=http://localhost:3000/examples/basic` in the browser)

```diff
diff --git a/packages/debugger/app/components/frame-ui.tsx b/packages/debugger/app/components/frame-ui.tsx
index 7bb7d10d..78536e5c 100644
--- a/packages/debugger/app/components/frame-ui.tsx
+++ b/packages/debugger/app/components/frame-ui.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 import defaultImageLoader from "next/dist/shared/lib/image-loader";
 import React from "react";
 import type { ImageLoaderProps } from "next/dist/shared/lib/image-config";
+import { Frame } from "frames.js";
 
 type Props = Omit<
   React.ComponentProps<
@@ -16,6 +17,59 @@ type Props = Omit<
 >;
 
 const components: Props["components"] = {
+  ButtonsContainer(props, stylingProps) {
+    if (
+      props.frameState.status === "loading" ||
+      !props.frameState.frame.buttons ||
+      props.frameState.frame.buttons.length === 0
+    ) {
+      return <></>;
+    }
+
+    const buttons = [...props.frameState.frame.buttons].sort((a, b) => {
+      const order: { [key: string]: number } = { post_redirect: 0, link: 0 };
+      const aOrder = order[a.action] ?? 1;
+      const bOrder = order[b.action] ?? 1;
+      return aOrder - bOrder;
+    });
+
+    return (
+      <div {...stylingProps}>
+        {buttons.map((frameButton, index) =>
+          this.Button?.(
+            {
+              frameState: props.frameState,
+              frameButton,
+              index,
+              // @TODO provide previous frame to pending state so we can remove loading check and render some loading indicator?
+              isDisabled: false,
+              onPress() {
+                // track dimensions of the root if possible
+                // rootDimensionsRef.current =
+                //   rootRef.current?.computeDimensions();
+                if (props.frameState.status === "loading") {
+                  return;
+                }
+
+                Promise.resolve(
+                  props.frameState.frameState.onButtonPress(
+                    // @todo change the type onButtonPress to accept partial frame as well because that can happen if partial frames are enabled
+                    props.frameState.frame as Frame,
+                    frameButton,
+                    index
+                  )
+                ).catch((error) => {
+                  // eslint-disable-next-line no-console -- provide feedback to the user
+                  console.error(error);
+                });
+              },
+            },
+            theme?.Button || {}
+          )
+        )}
+      </div>
+    );
+  },
   Button(
     { frameButton, isDisabled, onPress, index, frameState },
     stylingProps
diff --git a/templates/next-starter-with-examples/app/examples/basic/frames/next/route.tsx b/templates/next-starter-with-examples/app/examples/basic/frames/next/route.tsx
index 9c6ab573..e58780e2 100644
--- a/templates/next-starter-with-examples/app/examples/basic/frames/next/route.tsx
+++ b/templates/next-starter-with-examples/app/examples/basic/frames/next/route.tsx
@@ -10,6 +10,9 @@ const handleRequest = frames(async (ctx) => {
         {ctx.pressedButton ? "✅" : "❌"}
       </span>
     ),
+    imageOptions: {
+      aspectRatio: "1:1",
+    },
     buttons: [
       <Button action="post" target="/">
         Previous frame
diff --git a/templates/next-starter-with-examples/app/examples/basic/frames/route.tsx b/templates/next-starter-with-examples/app/examples/basic/frames/route.tsx
index 4caad283..ef6dffcc 100644
--- a/templates/next-starter-with-examples/app/examples/basic/frames/route.tsx
+++ b/templates/next-starter-with-examples/app/examples/basic/frames/route.tsx
@@ -12,6 +12,12 @@ const handleRequest = frames(async (ctx) => {
     ),
     buttons: [
       <Button action="post">Click me</Button>,
+      <Button action="link" target="/">
+        Link 1
+      </Button>,
+      <Button action="link" target="/">
+        Link 2
+      </Button>,
       <Button action="post" target="/next">
         Next frame
       </Button>,

```

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [ ] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
