### PR TITLE
feat: pass buttons' props separately to FrameButtonContainer

### DIFF
--- a/.changeset/rich-experts-suffer.md
+++ b/.changeset/rich-experts-suffer.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/render": patch
+---
+
+feat: pass buttons' props separately to FrameButtonContainer

--- a/packages/render/src/ui/frame.base.tsx
+++ b/packages/render/src/ui/frame.base.tsx
@@ -241,6 +241,34 @@ export function BaseFrameUI<TStylingProps extends Record<string, unknown>>({
   const isLoading =
     frameUiState.status === "loading" || frameUiState.isImageLoading;
 
+  const buttonsProps =
+    frameUiState.status === "loading" ||
+    !frameUiState.frame.buttons ||
+    frameUiState.frame.buttons.length === 0
+      ? null
+      : frameUiState.frame.buttons.map((frameButton, index) => ({
+          frameState: frameUiState,
+          frameButton,
+          index,
+          isDisabled: false,
+          onPress() {
+            // track dimensions of the root if possible
+            rootDimensionsRef.current = rootRef.current?.computeDimensions();
+
+            Promise.resolve(
+              frameState.onButtonPress(
+                // @todo change the type onButtonPress to accept partial frame as well because that can happen if partial frames are enabled
+                frameUiState.frame as Frame,
+                frameButton,
+                index
+              )
+            ).catch((error) => {
+              // eslint-disable-next-line no-console -- provide feedback to the user
+              console.error(error);
+            });
+          },
+        }));
+
   return components.Root(
     {
       createElement,
@@ -259,40 +287,19 @@ export function BaseFrameUI<TStylingProps extends Record<string, unknown>>({
       buttonsContainer:
         frameUiState.status === "loading" ||
         !frameUiState.frame.buttons ||
-        frameUiState.frame.buttons.length === 0
+        frameUiState.frame.buttons.length === 0 ||
+        !buttonsProps
           ? null
           : components.ButtonsContainer(
               {
                 frameState: frameUiState,
-                buttons: frameUiState.frame.buttons.map((frameButton, index) =>
+                buttons: buttonsProps.map((buttonProps) =>
                   components.Button(
-                    {
-                      frameState: frameUiState,
-                      frameButton,
-                      index,
-                      // @TODO provide previous frame to pending state so we can remove loading check and render some loading indicator?
-                      isDisabled: false,
-                      onPress() {
-                        // track dimensions of the root if possible
-                        rootDimensionsRef.current =
-                          rootRef.current?.computeDimensions();
-
-                        Promise.resolve(
-                          frameState.onButtonPress(
-                            // @todo change the type onButtonPress to accept partial frame as well because that can happen if partial frames are enabled
-                            frameUiState.frame as Frame,
-                            frameButton,
-                            index
-                          )
-                        ).catch((error) => {
-                          // eslint-disable-next-line no-console -- provide feedback to the user
-                          console.error(error);
-                        });
-                      },
-                    },
+                    buttonProps,
                     theme?.Button || ({} as TStylingProps)
                   )
                 ),
+                buttonsProps: buttonsProps,
               },
               theme?.ButtonsContainer || ({} as TStylingProps)
             ),

--- a/packages/render/src/ui/frame.base.tsx
+++ b/packages/render/src/ui/frame.base.tsx
@@ -284,25 +284,21 @@ export function BaseFrameUI<TStylingProps extends Record<string, unknown>>({
             theme?.LoadingScreen || ({} as TStylingProps)
           )
         : null,
-      buttonsContainer:
-        frameUiState.status === "loading" ||
-        !frameUiState.frame.buttons ||
-        frameUiState.frame.buttons.length === 0 ||
-        !buttonsProps
-          ? null
-          : components.ButtonsContainer(
-              {
-                frameState: frameUiState,
-                buttons: buttonsProps.map((buttonProps) =>
-                  components.Button(
-                    buttonProps,
-                    theme?.Button || ({} as TStylingProps)
-                  )
-                ),
-                buttonsProps: buttonsProps,
-              },
-              theme?.ButtonsContainer || ({} as TStylingProps)
-            ),
+      buttonsContainer: buttonsProps
+        ? components.ButtonsContainer(
+            {
+              frameState: frameUiState,
+              buttons: buttonsProps.map((buttonProps) =>
+                components.Button(
+                  buttonProps,
+                  theme?.Button || ({} as TStylingProps)
+                )
+              ),
+              buttonsProps,
+            },
+            theme?.ButtonsContainer || ({} as TStylingProps)
+          )
+        : null,
       imageContainer: components.ImageContainer(
         {
           frameState: frameUiState,

--- a/packages/render/src/ui/types.ts
+++ b/packages/render/src/ui/types.ts
@@ -82,6 +82,8 @@ export type FrameLoadingScreenProps = FrameUIStateProps & {
 
 export type FrameButtonContainerProps = {
   buttons: ReactElement[];
+  /** Props passed to buttons in the container */
+  buttonsProps: FrameButtonProps[];
 } & FrameUIStateProps;
 
 export type FrameTextInputContainerProps = {


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Passes button props alongside the button elements to the `FrameButtonContainer` component in case the props need to be transformed or reordered at render time.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
