### PR TITLE
fix: UNIX timestamp in milliseconds in farcaster untrusted data

### DIFF
--- a/.changeset/good-buckets-work.md
+++ b/.changeset/good-buckets-work.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/render": patch
+---
+
+fix: UNIX timestamp in milliseconds in farcaster untrusted data

--- a/packages/render/src/farcaster/frames.tsx
+++ b/packages/render/src/farcaster/frames.tsx
@@ -82,7 +82,7 @@ export const signFrameAction: SignFrameActionFunc<FarcasterSigner> = async (
         fid: signer.fid,
         url,
         messageHash: `0x${Buffer.from(message.hash).toString("hex")}`,
-        timestamp: message.data.timestamp,
+        timestamp: new Date().getTime(),
         network: 1,
         buttonIndex: Number(message.data.frameActionBody.buttonIndex),
         castId: {


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
Fixes an issue where some frame servers would reject the frame message because it is too old. This is because the untrustedData timestamp is expected to be a UNIX timestamp in milliseconds, not a farcaster epoch in seconds (source: https://warpcast.com/horsefacts.eth/0x18fa6881)

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [x] PR updates the boilerplates if necessary
