### PR TITLE
feat: transaction event listeners

### DIFF
--- a/.changeset/fair-singers-look.md
+++ b/.changeset/fair-singers-look.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/render": patch
+---
+
+feat: transaction event listeners

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -36,6 +36,16 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./errors": {
+      "import": {
+        "types": "./dist/errors.d.ts",
+        "default": "./dist/errors.js"
+      },
+      "require": {
+        "types": "./dist/errors.d.cts",
+        "default": "./dist/errors.cjs"
+      }
+    },
     "./next": {
       "import": {
         "types": "./dist/next/index.d.ts",

--- a/packages/render/src/errors.ts
+++ b/packages/render/src/errors.ts
@@ -1,0 +1,35 @@
+export class TransactionDataTargetMalformedError extends Error {
+  constructor(public readonly response: Response) {
+    super("Malformed transaction target data from the server");
+  }
+}
+
+export class TransactionDataErrorResponseError extends Error {
+  constructor(public readonly response: Response) {
+    super("Non OK transaction data response from the server");
+  }
+}
+
+export class TransactionHandlerDidNotReturnTransactionIdError extends Error {
+  constructor() {
+    super("onTransaction() handler did not return a transaction id");
+  }
+}
+
+export class SignatureHandlerDidNotReturnTransactionIdError extends Error {
+  constructor() {
+    super("onSignature() handler did not return a transaction id");
+  }
+}
+
+export class CastActionUnexpectedResponseError extends Error {
+  constructor() {
+    super("Unexpected cast action response from the server");
+  }
+}
+
+export class ComposerActionUnexpectedResponseError extends Error {
+  constructor() {
+    super("Unexpected composer action response from the server");
+  }
+}

--- a/packages/render/src/helpers.ts
+++ b/packages/render/src/helpers.ts
@@ -1,0 +1,27 @@
+export async function tryCallAsync<TResult>(
+  promiseFn: () => Promise<TResult>
+): Promise<TResult | Error> {
+  try {
+    return promiseFn().catch((e) => {
+      if (e instanceof Error) {
+        return e;
+      }
+
+      return new TypeError("Unexpected error, check the console for details");
+    });
+  } catch (e) {
+    return new TypeError("Unexpected error, check the console for details");
+  }
+}
+
+export function tryCall<TReturn>(fn: () => TReturn): TReturn | Error {
+  try {
+    return fn();
+  } catch (e) {
+    if (e instanceof Error) {
+      return e;
+    }
+
+    return new TypeError("Unexpected error, check the console for details");
+  }
+}

--- a/packages/render/src/types.ts
+++ b/packages/render/src/types.ts
@@ -5,6 +5,7 @@ import type {
   FrameButtonPost,
   FrameButtonTx,
   SupportedParsingSpecification,
+  TransactionTargetResponse,
   TransactionTargetResponseSendTransaction,
   TransactionTargetResponseSignTypedDataV4,
   getFrame,
@@ -140,6 +141,72 @@ export type UseFetchFrameOptions<
    * This function is called when the frame returns a redirect in response to post_redirect button click.
    */
   onRedirect: (location: URL) => void;
+  /**
+   * Called when user presses the tx button just before the action is signed and sent to the server
+   * to obtain the transaction data.
+   */
+  onTransactionDataStart?: (event: { button: FrameButtonTx }) => void;
+  /**
+   * Called when transaction data has been successfully returned from the server.
+   */
+  onTransactionDataSuccess?: (event: {
+    button: FrameButtonTx;
+    data: TransactionTargetResponse;
+  }) => void;
+  /**
+   * Called when anything failed between onTransactionDataStart and obtaining the transaction data.
+   */
+  onTransactionDataError?: (error: Error) => void;
+  /**
+   * Called before onTransaction() is called
+   * Called after onTransactionDataSuccess() is called
+   */
+  onTransactionStart?: (event: {
+    button: FrameButtonTx;
+    data: TransactionTargetResponseSendTransaction;
+  }) => void;
+  /**
+   * Called when onTransaction() returns a transaction id
+   */
+  onTransactionSuccess?: (event: { button: FrameButtonTx }) => void;
+  /**
+   * Called when onTransaction() fails to return a transaction id
+   */
+  onTransactionError?: (error: Error) => void;
+  /**
+   * Called before onSignature() is called
+   * Called after onTransactionDataSuccess() is called
+   */
+  onSignatureStart?: (event: {
+    button: FrameButtonTx;
+    data: TransactionTargetResponseSignTypedDataV4;
+  }) => void;
+  /**
+   * Called when onSignature() returns a transaction id
+   */
+  onSignatureSuccess?: (event: { button: FrameButtonTx }) => void;
+  /**
+   * Called when onSignature() fails to return a transaction id
+   */
+  onSignatureError?: (error: Error) => void;
+  /**
+   * Called after either onSignatureSuccess() or onTransactionSuccess() is called just before the transaction is sent to the server.
+   */
+  onTransactionProcessingStart?: (event: {
+    button: FrameButtonTx;
+    transactionId: `0x${string}`;
+  }) => void;
+  /**
+   * Called after the transaction has been successfully sent to the server and returned a success response.
+   */
+  onTransactionProcessingSuccess?: (event: {
+    button: FrameButtonTx;
+    transactionId: `0x${string}`;
+  }) => void;
+  /**
+   * Called when the transaction has been sent to the server but the server returned an error.
+   */
+  onTransactionProcessingError?: (error: Error) => void;
 };
 
 export type UseFrameOptions<
@@ -200,7 +267,21 @@ export type UseFrameOptions<
    */
   onLinkButtonClick?: (button: FrameButtonLink) => void;
 } & Partial<
-  Pick<UseFetchFrameOptions, "fetchFn" | "onRedirect" | "onComposerFormAction">
+  Pick<
+    UseFetchFrameOptions,
+    | "fetchFn"
+    | "onRedirect"
+    | "onComposerFormAction"
+    | "onTransactionDataError"
+    | "onTransactionDataStart"
+    | "onTransactionDataSuccess"
+    | "onTransactionError"
+    | "onTransactionStart"
+    | "onTransactionSuccess"
+    | "onTransactionProcessingError"
+    | "onTransactionProcessingStart"
+    | "onTransactionProcessingSuccess"
+  >
 >;
 
 type SignerStateActionSharedContext<

--- a/packages/render/src/use-frame-stack.ts
+++ b/packages/render/src/use-frame-stack.ts
@@ -130,6 +130,12 @@ export type FrameStackAPI = {
   >(arg: {
     action: SignedFrameAction;
     request: FramePOSTRequest<TSignerStateActionContext>;
+    /**
+     * Optional, allows to override the start time
+     *
+     * @defaultValue new Date()
+     */
+    startTime?: Date;
   }) => FrameStackPostPending;
   /**
    * Creates a pending item without dispatching it
@@ -285,7 +291,7 @@ export function useFrameStack({
             searchParams: arg.action.searchParams,
           },
           url: arg.action.searchParams.get("postUrl") ?? "missing postUrl",
-          timestamp: new Date(),
+          timestamp: arg.startTime ?? new Date(),
           status: "pending",
         };
 

--- a/packages/render/src/use-frame.tsx
+++ b/packages/render/src/use-frame.tsx
@@ -130,7 +130,7 @@ function defaultComposerFormActionHandler(): Promise<never> {
  * @param target - The target URL to validate.
  * @returns True if the target is a valid HTTP or HTTPS URL, otherwise throws an error.
  */
-function validateLinkButtonTarget(target: string) {
+function validateLinkButtonTarget(target: string): boolean {
   // check the URL is valid
   const locationUrl = new URL(target);
 
@@ -147,7 +147,7 @@ function validateLinkButtonTarget(target: string) {
 export function useFrame<
   TSignerStorageType = Record<string, unknown>,
   TFrameActionBodyType extends FrameActionBodyPayload = FrameActionBodyPayload,
-  TFrameContextType extends FrameContext = FarcasterFrameContext
+  TFrameContextType extends FrameContext = FarcasterFrameContext,
 >({
   homeframeUrl,
   frameContext,
@@ -171,6 +171,15 @@ export function useFrame<
   onRedirect = handleRedirectFallback,
   fetchFn = (...args) => fetch(...args),
   onComposerFormAction = defaultComposerFormActionHandler,
+  onTransactionDataError,
+  onTransactionDataStart,
+  onTransactionDataSuccess,
+  onTransactionError,
+  onTransactionProcessingError,
+  onTransactionProcessingStart,
+  onTransactionProcessingSuccess,
+  onTransactionStart,
+  onTransactionSuccess,
 }: UseFrameOptions<
   TSignerStorageType,
   TFrameActionBodyType,
@@ -209,6 +218,15 @@ export function useFrame<
     fetchFn,
     onRedirect,
     onComposerFormAction,
+    onTransactionDataError,
+    onTransactionDataStart,
+    onTransactionDataSuccess,
+    onTransactionError,
+    onTransactionProcessingError,
+    onTransactionProcessingStart,
+    onTransactionProcessingSuccess,
+    onTransactionStart,
+    onTransactionSuccess,
   });
 
   const fetchFrameRef = useRef(fetchFrame);


### PR DESCRIPTION
## Change Summary

This PR adds event listeners to `useFrame()` so you have more finer control when implementing an UI feedback.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
