### PR TITLE
feat: mini app support

### DIFF
--- a/.changeset/grumpy-berries-love.md
+++ b/.changeset/grumpy-berries-love.md
@@ -1,0 +1,6 @@
+---
+"@frames.js/debugger": patch
+"@frames.js/render": patch
+---
+
+feat: useComposerAction hook

--- a/packages/debugger/app/components/composer-action-debugger.tsx
+++ b/packages/debugger/app/components/composer-action-debugger.tsx
@@ -1,0 +1,51 @@
+import type {
+  ComposerActionResponse,
+  ComposerActionState,
+} from "frames.js/types";
+import { CastComposer, CastComposerRef } from "./cast-composer";
+import { useRef, useState } from "react";
+import { ComposerFormActionDialog } from "./composer-form-action-dialog";
+import { useFarcasterIdentity } from "../hooks/useFarcasterIdentity";
+
+type ComposerActionDebuggerProps = {
+  url: string;
+  actionMetadata: Partial<ComposerActionResponse>;
+  onToggleToCastActionDebugger: () => void;
+};
+
+export function ComposerActionDebugger({
+  actionMetadata,
+  url,
+  onToggleToCastActionDebugger,
+}: ComposerActionDebuggerProps) {
+  const castComposerRef = useRef<CastComposerRef>(null);
+  const signer = useFarcasterIdentity();
+  const [actionState, setActionState] = useState<ComposerActionState | null>(
+    null
+  );
+
+  return (
+    <>
+      <CastComposer
+        composerAction={actionMetadata}
+        onComposerActionClick={setActionState}
+        ref={castComposerRef}
+      />
+      {!!actionState && (
+        <ComposerFormActionDialog
+          actionState={actionState}
+          signer={signer}
+          url={url}
+          onClose={() => {
+            setActionState(null);
+          }}
+          onSubmit={(newActionState) => {
+            castComposerRef.current?.updateState(newActionState);
+            setActionState(null);
+          }}
+          onToggleToCastActionDebugger={onToggleToCastActionDebugger}
+        />
+      )}
+    </>
+  );
+}

--- a/packages/debugger/app/components/composer-form-action-dialog.tsx
+++ b/packages/debugger/app/components/composer-form-action-dialog.tsx
@@ -5,221 +5,158 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { OnSignatureFunc, OnTransactionFunc } from "@frames.js/render";
-import type {
-  ComposerActionFormResponse,
-  ComposerActionState,
-} from "frames.js/types";
-import { useCallback, useEffect, useRef } from "react";
-import { Abi, TypedDataDomain } from "viem";
-import { z } from "zod";
-
-const createCastRequestSchemaLegacy = z.object({
-  type: z.literal("createCast"),
-  data: z.object({
-    cast: z.object({
-      parent: z.string().optional(),
-      text: z.string(),
-      embeds: z.array(z.string().min(1).url()).min(1),
-    }),
-  }),
-});
-
-const ethSendTransactionActionSchema = z.object({
-  chainId: z.string(),
-  method: z.literal("eth_sendTransaction"),
-  attribution: z.boolean().optional(),
-  params: z.object({
-    abi: z.custom<Abi>(),
-    to: z.custom<`0x${string}`>(
-      (val): val is `0x${string}` =>
-        typeof val === "string" && val.startsWith("0x")
-    ),
-    value: z.string().optional(),
-    data: z
-      .custom<`0x${string}`>(
-        (val): val is `0x${string}` =>
-          typeof val === "string" && val.startsWith("0x")
-      )
-      .optional(),
-  }),
-});
-
-const ethSignTypedDataV4ActionSchema = z.object({
-  chainId: z.string(),
-  method: z.literal("eth_signTypedData_v4"),
-  params: z.object({
-    domain: z.custom<TypedDataDomain>(),
-    types: z.unknown(),
-    primaryType: z.string(),
-    message: z.record(z.unknown()),
-  }),
-});
-
-const walletActionRequestSchema = z.object({
-  jsonrpc: z.literal("2.0"),
-  id: z.string(),
-  method: z.literal("fc_requestWalletAction"),
-  params: z.object({
-    action: z.union([
-      ethSendTransactionActionSchema,
-      ethSignTypedDataV4ActionSchema,
-    ]),
-  }),
-});
-
-const createCastRequestSchema = z.object({
-  jsonrpc: z.literal("2.0"),
-  id: z.union([z.string(), z.number(), z.null()]),
-  method: z.literal("fc_createCast"),
-  params: z.object({
-    cast: z.object({
-      parent: z.string().optional(),
-      text: z.string(),
-      embeds: z.array(z.string().min(1).url()).min(1),
-    }),
-  }),
-});
-
-const composerActionMessageSchema = z.union([
-  createCastRequestSchemaLegacy,
-  walletActionRequestSchema,
-  createCastRequestSchema,
-]);
+import { useComposerAction } from "@frames.js/render/use-composer-action";
+import type { ComposerActionState } from "frames.js/types";
+import { useRef } from "react";
+import {
+  useAccount,
+  useChainId,
+  useSendTransaction,
+  useSignTypedData,
+  useSwitchChain,
+} from "wagmi";
+import { useConnectModal } from "@rainbow-me/rainbowkit";
+import { useToast } from "@/components/ui/use-toast";
+import { ToastAction } from "@/components/ui/toast";
+import { parseEther } from "viem";
+import { parseChainId } from "../lib/utils";
+import { FarcasterMultiSignerInstance } from "@frames.js/render/identity/farcaster";
+import { AlertTriangleIcon, Loader2Icon } from "lucide-react";
 
 type ComposerFormActionDialogProps = {
-  composerActionForm: ComposerActionFormResponse;
+  actionState: ComposerActionState;
+  url: string;
+  signer: FarcasterMultiSignerInstance;
   onClose: () => void;
-  onSave: (arg: { composerState: ComposerActionState }) => void;
-  onTransaction?: OnTransactionFunc;
-  onSignature?: OnSignatureFunc;
-  // TODO: Consider moving this into return value of onTransaction
-  connectedAddress?: `0x${string}`;
+  onSubmit: (actionState: ComposerActionState) => void;
+  onToggleToCastActionDebugger: () => void;
 };
 
-export function ComposerFormActionDialog({
-  composerActionForm,
+export const ComposerFormActionDialog = ({
+  actionState,
+  signer,
+  url,
   onClose,
-  onSave,
-  onTransaction,
-  onSignature,
-  connectedAddress,
-}: ComposerFormActionDialogProps) {
-  const onSaveRef = useRef(onSave);
-  onSaveRef.current = onSave;
-
+  onSubmit,
+  onToggleToCastActionDebugger,
+}: ComposerFormActionDialogProps) => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const { toast } = useToast();
+  const account = useAccount();
+  const currentChainId = useChainId();
+  const { switchChainAsync } = useSwitchChain();
+  const { sendTransactionAsync } = useSendTransaction();
+  const { signTypedDataAsync } = useSignTypedData();
+  const { openConnectModal } = useConnectModal();
 
-  const postMessageToIframe = useCallback(
-    (message: any) => {
+  const result = useComposerAction({
+    url,
+    enabled: !signer.isLoadingSigner,
+    proxyUrl: "/frames",
+    actionState,
+    signer,
+    async resolveAddress() {
+      if (account.address) {
+        return account.address;
+      }
+
+      if (!openConnectModal) {
+        throw new Error("Connect modal is not available");
+      }
+
+      openConnectModal();
+
+      return null;
+    },
+    onError(error) {
+      console.error(error);
+
+      if (
+        error.message.includes(
+          "Unexpected composer action response from the server"
+        )
+      ) {
+        toast({
+          title: "Error occurred",
+          description:
+            "It seems that you tried to call a cast action in the composer action debugger.",
+          variant: "destructive",
+          action: (
+            <ToastAction
+              altText="Switch to cast action debugger"
+              onClick={() => {
+                onToggleToCastActionDebugger();
+              }}
+            >
+              Switch
+            </ToastAction>
+          ),
+        });
+
+        return;
+      }
+
+      toast({
+        title: "Error occurred",
+        description: (
+          <div className="space-y-2">
+            <p>{error.message}</p>
+            <p>Please check the console for more information</p>
+          </div>
+        ),
+        variant: "destructive",
+      });
+    },
+    async onCreateCast(arg) {
+      onSubmit(arg.cast);
+    },
+    async onSignature({ action, address }) {
+      const { chainId, params } = action;
+      const requestedChainId = parseChainId(chainId);
+
+      if (currentChainId !== requestedChainId) {
+        await switchChainAsync({ chainId: requestedChainId });
+      }
+
+      const hash = await signTypedDataAsync(params);
+
+      return {
+        address,
+        hash,
+      };
+    },
+    async onTransaction({ action, address }) {
+      const { chainId, params } = action;
+      const requestedChainId = parseChainId(chainId);
+
+      if (currentChainId !== requestedChainId) {
+        await switchChainAsync({ chainId: requestedChainId });
+      }
+
+      const hash = await sendTransactionAsync({
+        to: params.to,
+        data: params.data,
+        value: parseEther(params.value ?? "0"),
+      });
+
+      return {
+        address,
+        hash,
+      };
+    },
+    onPostResponseToTarget(message, form) {
       if (iframeRef.current && iframeRef.current.contentWindow) {
         iframeRef.current.contentWindow.postMessage(
           message,
-          new URL(composerActionForm.url).origin
+          new URL(form.url).origin
         );
       }
     },
-    [composerActionForm.url]
-  );
+  });
 
-  useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      if (event.origin !== new URL(composerActionForm.url).origin) {
-        return;
-      }
-
-      const result = composerActionMessageSchema.safeParse(event.data);
-
-      // on error is not called here because there can be different messages that don't have anything to do with composer form actions
-      // instead we are just waiting for the correct message
-      if (!result.success) {
-        console.warn("Invalid message received", event.data, result.error);
-        return;
-      }
-
-      const message = result.data;
-
-      if ("type" in message) {
-        // Handle legacy messages
-        onSaveRef.current({
-          composerState: message.data.cast,
-        });
-      } else if (message.method === "fc_requestWalletAction") {
-        if (message.params.action.method === "eth_sendTransaction") {
-          onTransaction?.({
-            transactionData: message.params.action,
-          }).then((txHash) => {
-            if (txHash) {
-              postMessageToIframe({
-                jsonrpc: "2.0",
-                id: message.id,
-                result: {
-                  address: connectedAddress,
-                  transactionId: txHash,
-                },
-              });
-            } else {
-              postMessageToIframe({
-                jsonrpc: "2.0",
-                id: message.id,
-                error: {
-                  code: -32000,
-                  message: "User rejected the request",
-                },
-              });
-            }
-          });
-        } else if (message.params.action.method === "eth_signTypedData_v4") {
-          onSignature?.({
-            signatureData: {
-              chainId: message.params.action.chainId,
-              method: message.params.action.method,
-              params: {
-                domain: message.params.action.params.domain,
-                types: message.params.action.params.types as any,
-                primaryType: message.params.action.params.primaryType,
-                message: message.params.action.params.message,
-              },
-            },
-          }).then((signature) => {
-            if (signature) {
-              postMessageToIframe({
-                jsonrpc: "2.0",
-                id: message.id,
-                result: {
-                  address: connectedAddress,
-                  transactionId: signature,
-                },
-              });
-            } else {
-              postMessageToIframe({
-                jsonrpc: "2.0",
-                id: message.id,
-                error: {
-                  code: -32000,
-                  message: "User rejected the request",
-                },
-              });
-            }
-          });
-        }
-      } else if (message.method === "fc_createCast") {
-        if (message.params.cast.embeds.length > 2) {
-          console.warn("Only first 2 embeds are shown in the cast");
-        }
-
-        onSaveRef.current({
-          composerState: message.params.cast,
-        });
-      }
-    };
-
-    window.addEventListener("message", handleMessage);
-
-    return () => {
-      window.removeEventListener("message", handleMessage);
-    };
-  }, []);
+  if (result.status === "idle") {
+    return null;
+  }
 
   return (
     <Dialog
@@ -231,23 +168,47 @@ export function ComposerFormActionDialog({
       }}
     >
       <DialogContent>
-        <DialogHeader>
-          <DialogTitle>{composerActionForm.title}</DialogTitle>
-        </DialogHeader>
-        <div>
-          <iframe
-            className="h-[600px] w-full opacity-100 transition-opacity duration-300"
-            ref={iframeRef}
-            src={composerActionForm.url}
-            sandbox="allow-forms allow-scripts allow-same-origin"
-          ></iframe>
-        </div>
-        <DialogFooter>
-          <span className="text-gray-400 text-sm">
-            {new URL(composerActionForm.url).hostname}
-          </span>
-        </DialogFooter>
+        {result.status === "loading" && (
+          <>
+            <div className="flex items-center justify-center">
+              <Loader2Icon className="text-slate-400 animate-spin" size={40} />
+            </div>
+          </>
+        )}
+        {result.status === "error" && (
+          <>
+            <div className="flex flex-col items-center gap-2">
+              <AlertTriangleIcon className="text-red-500 mb-4" size={40} />
+              <p className="font-semibold text-lg text-red-500">
+                Something went wrong
+              </p>
+              <p className="text-red-400">Check the console</p>
+            </div>
+          </>
+        )}
+        {result.status === "success" && (
+          <>
+            <DialogHeader>
+              <DialogTitle>{result.data.title}</DialogTitle>
+            </DialogHeader>
+            <div>
+              <iframe
+                className="h-[600px] w-full opacity-100 transition-opacity duration-300"
+                ref={iframeRef}
+                src={result.data.url}
+                sandbox="allow-forms allow-scripts allow-same-origin"
+              ></iframe>
+            </div>
+            <DialogFooter>
+              <span className="text-gray-400 text-sm">
+                {new URL(result.data.url).hostname}
+              </span>
+            </DialogFooter>
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );
-}
+};
+
+ComposerFormActionDialog.displayName = "ComposerFormActionDialog";

--- a/packages/debugger/app/components/composer-form-action-dialog.tsx
+++ b/packages/debugger/app/components/composer-form-action-dialog.tsx
@@ -144,7 +144,7 @@ export const ComposerFormActionDialog = ({
         hash,
       };
     },
-    onPostResponseToTarget(message, form) {
+    onMessageRespond(message, form) {
       if (iframeRef.current && iframeRef.current.contentWindow) {
         iframeRef.current.contentWindow.postMessage(
           message,

--- a/packages/debugger/app/frames/route.ts
+++ b/packages/debugger/app/frames/route.ts
@@ -1,51 +1,11 @@
-import { type FrameActionPayload } from "frames.js";
+import { POST as handlePOSTRequest } from "@frames.js/render/next";
 import { type NextRequest } from "next/server";
 import { getAction } from "../actions/getAction";
 import { persistMockResponsesForDebugHubRequests } from "../utils/mock-hub-utils";
 import type { SupportedParsingSpecification } from "frames.js";
 import { parseFramesWithReports } from "frames.js/parseFramesWithReports";
-import { z } from "zod";
 import type { ParseActionResult } from "../actions/types";
 import type { ParseFramesWithReportsResult } from "frames.js/frame-parsers";
-import type { JsonObject } from "frames.js/types";
-
-const castActionMessageParser = z.object({
-  type: z.literal("message"),
-  message: z.string().min(1),
-});
-
-const castActionFrameParser = z.object({
-  type: z.literal("frame"),
-  frameUrl: z.string().min(1).url(),
-});
-
-const composerActionFormParser = z.object({
-  type: z.literal("form"),
-  url: z.string().min(1).url(),
-  title: z.string().min(1),
-});
-
-const jsonResponseParser = z.preprocess(
-  (data) => {
-    if (typeof data === "object" && data !== null && !("type" in data)) {
-      return {
-        type: "message",
-        ...data,
-      };
-    }
-
-    return data;
-  },
-  z.discriminatedUnion("type", [
-    castActionFrameParser,
-    castActionMessageParser,
-    composerActionFormParser,
-  ])
-);
-
-const errorResponseParser = z.object({
-  message: z.string().min(1),
-});
 
 export type CastActionDefinitionResponse = ParseActionResult & {
   type: "action";
@@ -126,129 +86,7 @@ export async function GET(request: NextRequest): Promise<Response> {
 
 /** Proxies frame actions to avoid CORS issues and preserve user IP privacy */
 export async function POST(req: NextRequest): Promise<Response> {
-  const body = (await req.clone().json()) as FrameActionPayload;
-  const isPostRedirect =
-    req.nextUrl.searchParams.get("postType") === "post_redirect";
-  const isTransactionRequest =
-    req.nextUrl.searchParams.get("postType") === "tx";
-  const postUrl = req.nextUrl.searchParams.get("postUrl");
-  const specification =
-    req.nextUrl.searchParams.get("specification") ?? "farcaster";
+  await persistMockResponsesForDebugHubRequests(req);
 
-  if (!isSpecificationValid(specification)) {
-    return Response.json({ message: "Invalid specification" }, { status: 400 });
-  }
-
-  // TODO: refactor useful logic back into render package
-
-  if (specification === "farcaster") {
-    await persistMockResponsesForDebugHubRequests(req);
-  }
-
-  if (!postUrl) {
-    return Response.json({ message: "Invalid post URL" }, { status: 400 });
-  }
-
-  try {
-    const r = await fetch(postUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      redirect: isPostRedirect ? "manual" : undefined,
-      body: JSON.stringify(body),
-    });
-
-    if (r.status === 302) {
-      return Response.json(
-        {
-          location: r.headers.get("location"),
-        },
-        { status: 302 }
-      );
-    }
-
-    // this is an error, just return response as is
-    if (r.status >= 500) {
-      return Response.json(await r.text(), { status: r.status });
-    }
-
-    if (r.status >= 400 && r.status < 500) {
-      const parseResult = await z
-        .promise(errorResponseParser)
-        .safeParseAsync(r.clone().json());
-
-      if (!parseResult.success) {
-        return Response.json(
-          { message: await r.clone().text() },
-          { status: r.status }
-        );
-      }
-
-      const headers = new Headers(r.headers);
-      // Proxied requests could have content-encoding set, which breaks the response
-      headers.delete("content-encoding");
-      return new Response(r.body, {
-        headers,
-        status: r.status,
-        statusText: r.statusText,
-      });
-    }
-
-    if (isPostRedirect && r.status !== 302) {
-      return Response.json(
-        {
-          message: `Invalid response status code for post redirect button, 302 expected, got ${r.status}`,
-        },
-        { status: 400 }
-      );
-    }
-
-    if (isTransactionRequest) {
-      const transaction = (await r.json()) as JsonObject;
-      return Response.json(transaction);
-    }
-
-    // Content type is JSON, could be an action
-    if (r.headers.get("content-type")?.includes("application/json")) {
-      const parseResult = await z
-        .promise(jsonResponseParser)
-        .safeParseAsync(r.clone().json());
-
-      if (!parseResult.success) {
-        throw new Error("Invalid frame response");
-      }
-
-      const headers = new Headers(r.headers);
-      // Proxied requests could have content-encoding set, which breaks the response
-      headers.delete("content-encoding");
-      return new Response(r.body, {
-        headers,
-        status: r.status,
-        statusText: r.statusText,
-      });
-    }
-
-    const html = await r.text();
-
-    const parseResult = parseFramesWithReports({
-      html,
-      fallbackPostUrl: body.untrustedData.url,
-      fromRequestMethod: "POST",
-    });
-
-    return Response.json({
-      type: "frame",
-      ...parseResult,
-    } satisfies FrameDefinitionResponse);
-  } catch (err) {
-    // eslint-disable-next-line no-console -- provide feedback to the user
-    console.error(err);
-    return Response.json(
-      {
-        message: String(err),
-      },
-      { status: 500 }
-    );
-  }
+  return handlePOSTRequest(req);
 }

--- a/packages/debugger/app/hooks/useFarcasterIdentity.tsx
+++ b/packages/debugger/app/hooks/useFarcasterIdentity.tsx
@@ -1,0 +1,44 @@
+import { ToastAction } from "@/components/ui/toast";
+import { useToast } from "@/components/ui/use-toast";
+import { useFarcasterMultiIdentity } from "@frames.js/render/identity/farcaster";
+import { WebStorage } from "@frames.js/render/identity/storage";
+
+const sharedStorage = new WebStorage();
+
+type Options = Omit<
+  Parameters<typeof useFarcasterMultiIdentity>[0],
+  "onMissingIdentity"
+> & {
+  selectProtocolButtonRef?: React.RefObject<HTMLButtonElement>;
+};
+
+export function useFarcasterIdentity({
+  selectProtocolButtonRef,
+  ...options
+}: Options = {}) {
+  const { toast } = useToast();
+
+  return useFarcasterMultiIdentity({
+    ...(options ?? {}),
+    storage: sharedStorage,
+    onMissingIdentity() {
+      toast({
+        title: "Please select an identity",
+        description:
+          "In order to test the buttons you need to select an identity first",
+        variant: "destructive",
+        action: selectProtocolButtonRef?.current ? (
+          <ToastAction
+            altText="Select identity"
+            onClick={() => {
+              selectProtocolButtonRef?.current?.click();
+            }}
+            type="button"
+          >
+            Select identity
+          </ToastAction>
+        ) : undefined,
+      });
+    },
+  });
+}

--- a/packages/debugger/app/lib/utils.ts
+++ b/packages/debugger/app/lib/utils.ts
@@ -18,3 +18,17 @@ export function hasWarnings(reports: Record<string, ParsingReport[]>): boolean {
     report.some((r) => r.level === "warning")
   );
 }
+
+export class InvalidChainIdError extends Error {}
+
+export function isValidChainId(id: string): boolean {
+  return id.startsWith("eip155:");
+}
+
+export function parseChainId(id: string): number {
+  if (!isValidChainId(id)) {
+    throw new InvalidChainIdError(`Invalid chainId ${id}`);
+  }
+
+  return parseInt(id.split("eip155:")[1]!);
+}

--- a/packages/debugger/app/utils/mock-hub-utils.ts
+++ b/packages/debugger/app/utils/mock-hub-utils.ts
@@ -71,13 +71,16 @@ export async function loadMockResponseForDebugHubRequest(
 }
 
 export async function persistMockResponsesForDebugHubRequests(req: Request) {
-  const {
-    mockData,
-    untrustedData: { fid: requesterFid, castId },
-  } = (await req.clone().json()) as {
-    mockData: MockHubActionContext;
-    untrustedData: { fid: string; castId: { fid: string; hash: string } };
+  const { mockData, untrustedData } = (await req.clone().json()) as {
+    mockData?: MockHubActionContext;
+    untrustedData?: { fid: string; castId?: { fid: string; hash: string } };
   };
+
+  if (!mockData || !untrustedData?.castId) {
+    return;
+  }
+
+  const { fid: requesterFid, castId } = untrustedData;
 
   const requesterFollowsCaster = `/v1/linkById?${sortedSearchParamsString(
     new URLSearchParams({

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -130,6 +130,16 @@
         "default": "./dist/use-frame.cjs"
       }
     },
+    "./use-composer-action": {
+      "import": {
+        "types": "./dist/use-composer-action.d.ts",
+        "default": "./dist/use-composer-action.js"
+      },
+      "require": {
+        "types": "./dist/use-composer-action.d.cts",
+        "default": "./dist/use-composer-action.cjs"
+      }
+    },
     "./unstable-use-debugger-frame-state": {
       "import": {
         "types": "./dist/unstable-use-debugger-frame-state.d.ts",
@@ -285,6 +295,7 @@
   "dependencies": {
     "@farcaster/core": "^0.14.7",
     "@noble/ed25519": "^2.0.0",
-    "frames.js": "^0.19.5"
+    "frames.js": "^0.19.5",
+    "zod": "^3.23.8"
   }
 }

--- a/packages/render/src/errors.ts
+++ b/packages/render/src/errors.ts
@@ -33,3 +33,9 @@ export class ComposerActionUnexpectedResponseError extends Error {
     super("Unexpected composer action response from the server");
   }
 }
+
+export class ComposerActionUserRejectedRequestError extends Error {
+  constructor() {
+    super("User rejected the request");
+  }
+}

--- a/packages/render/src/farcaster/frames.tsx
+++ b/packages/render/src/farcaster/frames.tsx
@@ -7,7 +7,7 @@ import {
   getFarcasterTime,
   makeFrameAction,
 } from "@farcaster/core";
-import { hexToBytes } from "viem";
+import { bytesToHex, hexToBytes } from "viem";
 import type {
   FrameActionBodyPayload,
   FrameContext,
@@ -15,8 +15,44 @@ import type {
   SignerStateActionContext,
   SignFrameActionFunc,
 } from "../types";
+import type {
+  SignComposerActionFunc,
+  SignerStateComposerActionContext,
+} from "../unstable-types";
+import { tryCallAsync } from "../helpers";
 import type { FarcasterSigner } from "./signers";
 import type { FarcasterFrameContext } from "./types";
+
+/**
+ * Creates a singer request payload to fetch composer action url.
+ */
+export const signComposerAction: SignComposerActionFunc =
+  async function signComposerAction(signerPrivateKey, actionContext) {
+    const messageOrError = await tryCallAsync(() =>
+      createComposerActionMessageWithSignerKey(signerPrivateKey, actionContext)
+    );
+
+    if (messageOrError instanceof Error) {
+      throw messageOrError;
+    }
+
+    const { message, trustedBytes } = messageOrError;
+
+    return {
+      untrustedData: {
+        buttonIndex: 1,
+        fid: actionContext.fid,
+        messageHash: bytesToHex(message.hash),
+        network: 1,
+        state: Buffer.from(message.data.frameActionBody.state).toString(),
+        timestamp: new Date().getTime(),
+        url: actionContext.url,
+      },
+      trustedData: {
+        messageBytes: trustedBytes,
+      },
+    };
+  };
 
 /** Creates a frame action for use with `useFrame` and a proxy */
 export const signFrameAction: SignFrameActionFunc<
@@ -103,6 +139,43 @@ export const signFrameAction: SignFrameActionFunc<
     },
   };
 };
+
+export async function createComposerActionMessageWithSignerKey(
+  signerKey: string,
+  { fid, state, url }: SignerStateComposerActionContext
+): Promise<{
+  message: FrameActionMessage;
+  trustedBytes: string;
+}> {
+  const signer = new NobleEd25519Signer(Buffer.from(signerKey.slice(2), "hex"));
+
+  const messageDataOptions = {
+    fid,
+    network: FarcasterNetwork.MAINNET,
+  };
+
+  const message = await makeFrameAction(
+    FrameActionBody.create({
+      url: Buffer.from(url),
+      buttonIndex: 1,
+      state: Buffer.from(encodeURIComponent(JSON.stringify({ cast: state }))),
+    }),
+    messageDataOptions,
+    signer
+  );
+
+  if (message.isErr()) {
+    throw message.error;
+  }
+
+  const messageData = message.value;
+
+  const trustedBytes = Buffer.from(
+    Message.encode(message._unsafeUnwrap()).finish()
+  ).toString("hex");
+
+  return { message: messageData, trustedBytes };
+}
 
 export async function createFrameActionMessageWithSignerKey(
   signerKey: string,

--- a/packages/render/src/farcaster/signers.tsx
+++ b/packages/render/src/farcaster/signers.tsx
@@ -1,4 +1,5 @@
 import type { FrameActionBodyPayload, SignerStateInstance } from "../types";
+import type { SignComposerActionFunc } from "../unstable-types";
 import type { FarcasterFrameContext } from "./types";
 
 export type FarcasterSignerState<TSignerType = FarcasterSigner | null> =
@@ -6,7 +7,9 @@ export type FarcasterSignerState<TSignerType = FarcasterSigner | null> =
     TSignerType,
     FrameActionBodyPayload,
     FarcasterFrameContext
-  >;
+  > & {
+    signComposerAction: SignComposerActionFunc;
+  };
 
 export type FarcasterSignerPendingApproval = {
   status: "pending_approval";

--- a/packages/render/src/helpers.ts
+++ b/packages/render/src/helpers.ts
@@ -2,6 +2,7 @@ import type {
   ParseFramesWithReportsResult,
   ParseResult,
 } from "frames.js/frame-parsers";
+import type { ComposerActionFormResponse } from "frames.js/types";
 import type { PartialFrame } from "./ui/types";
 
 export async function tryCallAsync<TResult>(
@@ -70,4 +71,38 @@ export function isPartialFrame(
     !!value.frame.buttons &&
     value.frame.buttons.length > 0
   );
+}
+
+export function isComposerFormActionResponse(
+  response: unknown
+): response is ComposerActionFormResponse {
+  return (
+    typeof response === "object" &&
+    response !== null &&
+    "type" in response &&
+    response.type === "form"
+  );
+}
+
+/**
+ * Merges all search params in order from left to right into the URL.
+ *
+ * @param url - The URL to merge the search params into. Either fully qualified or path only.
+ */
+export function mergeSearchParamsToUrl(
+  url: string,
+  ...searchParams: URLSearchParams[]
+): string {
+  const temporaryDomain = "temporary-for-parsing-purposes.tld";
+  const parsedProxyUrl = new URL(url, `http://${temporaryDomain}`);
+
+  searchParams.forEach((params) => {
+    params.forEach((value, key) => {
+      parsedProxyUrl.searchParams.set(key, value);
+    });
+  });
+
+  return parsedProxyUrl.hostname === temporaryDomain
+    ? `${parsedProxyUrl.pathname}${parsedProxyUrl.search}`
+    : parsedProxyUrl.toString();
 }

--- a/packages/render/src/identity/farcaster/use-farcaster-identity.tsx
+++ b/packages/render/src/identity/farcaster/use-farcaster-identity.tsx
@@ -8,11 +8,12 @@ import {
 } from "react";
 import { convertKeypairToHex, createKeypairEDDSA } from "../crypto";
 import type { FarcasterSignerState } from "../../farcaster";
-import { signFrameAction } from "../../farcaster";
+import { signComposerAction, signFrameAction } from "../../farcaster";
 import type { Storage } from "../types";
 import { useVisibilityDetection } from "../../hooks/use-visibility-detection";
 import { WebStorage } from "../storage";
 import { useStorage } from "../../hooks/use-storage";
+import { useFreshRef } from "../../hooks/use-fresh-ref";
 import { IdentityPoller } from "./identity-poller";
 import type {
   FarcasterCreateSignerResult,
@@ -187,16 +188,12 @@ export function useFarcasterIdentity({
       return value;
     },
   });
-  const onImpersonateRef = useRef(onImpersonate);
-  onImpersonateRef.current = onImpersonate;
-  const onLogInRef = useRef(onLogIn);
-  onLogInRef.current = onLogIn;
-  const onLogInStartRef = useRef(onLogInStart);
-  onLogInStartRef.current = onLogInStart;
-  const onLogOutRef = useRef(onLogOut);
-  onLogOutRef.current = onLogOut;
-  const generateUserIdRef = useRef(generateUserId);
-  generateUserIdRef.current = generateUserId;
+  const onImpersonateRef = useFreshRef(onImpersonate);
+  const onLogInRef = useFreshRef(onLogIn);
+  const onLogInStartRef = useFreshRef(onLogInStart);
+  const onLogOutRef = useFreshRef(onLogOut);
+  const generateUserIdRef = useFreshRef(generateUserId);
+  const onMissingIdentityRef = useFreshRef(onMissingIdentity);
 
   const createFarcasterSigner =
     useCallback(async (): Promise<FarcasterCreateSignerResult> => {
@@ -300,7 +297,7 @@ export function useFarcasterIdentity({
         console.error("@frames.js/render: API Call failed", error);
         throw error;
       }
-    }, [setState, signerUrl]);
+    }, [generateUserIdRef, onLogInStartRef, setState, signerUrl]);
 
   const impersonateUser = useCallback(
     async (fid: number) => {
@@ -329,14 +326,14 @@ export function useFarcasterIdentity({
         setIsLoading(false);
       }
     },
-    [setState]
+    [generateUserIdRef, onImpersonateRef, setState]
   );
 
   const onSignerlessFramePress = useCallback((): Promise<void> => {
-    onMissingIdentity();
+    onMissingIdentityRef.current();
 
     return Promise.resolve();
-  }, [onMissingIdentity]);
+  }, [onMissingIdentityRef]);
 
   const createSigner = useCallback(async () => {
     setIsLoading(true);
@@ -354,7 +351,7 @@ export function useFarcasterIdentity({
 
       return identityReducer(currentState, { type: "LOGOUT" });
     });
-  }, [setState]);
+  }, [onLogOutRef, setState]);
 
   const farcasterUser = state.status === "init" ? null : state;
 
@@ -418,6 +415,7 @@ export function useFarcasterIdentity({
     visibilityDetector,
     setState,
     enableIdentityPolling,
+    onLogInRef,
   ]);
 
   return useMemo(
@@ -428,6 +426,7 @@ export function useFarcasterIdentity({
         farcasterUser?.status === "approved" ||
         farcasterUser?.status === "impersonating",
       signFrameAction,
+      signComposerAction,
       isLoadingSigner: isLoading,
       impersonateUser,
       onSignerlessFramePress,

--- a/packages/render/src/mini-app-messages.ts
+++ b/packages/render/src/mini-app-messages.ts
@@ -1,4 +1,4 @@
-import type { Abi, TypedDataDomain } from "viem";
+import type { Abi, TypedData, TypedDataDomain } from "viem";
 import { z } from "zod";
 
 export type TransactionResponse =
@@ -100,7 +100,11 @@ const ethSignTypedDataV4ActionSchema = z.object({
   method: z.literal("eth_signTypedData_v4"),
   params: z.object({
     domain: z.custom<TypedDataDomain>(),
-    types: z.unknown(),
+    types: z.custom<TypedData>((value) => {
+      const result = z.record(z.unknown()).safeParse(value);
+
+      return result.success;
+    }),
     primaryType: z.string(),
     message: z.record(z.unknown()),
   }),

--- a/packages/render/src/mini-app-messages.ts
+++ b/packages/render/src/mini-app-messages.ts
@@ -1,0 +1,135 @@
+import type { Abi, TypedDataDomain } from "viem";
+import { z } from "zod";
+
+export type TransactionResponse =
+  | TransactionResponseSuccess
+  | TransactionResponseFailure;
+
+export type TransactionResponseSuccess = {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  result: TransactionSuccessBody;
+};
+
+export type TransactionSuccessBody =
+  | EthSendTransactionSuccessBody
+  | EthSignTypedDataV4SuccessBody;
+
+export type EthSendTransactionSuccessBody = {
+  address: `0x${string}`;
+  transactionHash: `0x${string}`;
+};
+
+export type EthSignTypedDataV4SuccessBody = {
+  address: `0x${string}`;
+  signature: `0x${string}`;
+};
+
+export type TransactionResponseFailure = {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  error: {
+    code: number;
+    message: string;
+  };
+};
+
+export type CreateCastResponse = {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  result: {
+    success: true;
+  };
+};
+
+export type MiniAppResponse = TransactionResponse | CreateCastResponse;
+
+const createCastRequestSchemaLegacy = z.object({
+  type: z.literal("createCast"),
+  data: z.object({
+    cast: z.object({
+      parent: z.string().optional(),
+      text: z.string(),
+      embeds: z.array(z.string().min(1).url()).min(1),
+    }),
+  }),
+});
+
+export type CreateCastLegacyMessage = z.infer<
+  typeof createCastRequestSchemaLegacy
+>;
+
+const createCastRequestSchema = z.object({
+  jsonrpc: z.literal("2.0"),
+  id: z.union([z.string(), z.number(), z.null()]),
+  method: z.literal("fc_createCast"),
+  params: z.object({
+    cast: z.object({
+      parent: z.string().optional(),
+      text: z.string(),
+      embeds: z.array(z.string().min(1).url()).min(1),
+    }),
+  }),
+});
+
+export type CreateCastMessage = z.infer<typeof createCastRequestSchema>;
+
+const ethSendTransactionActionSchema = z.object({
+  chainId: z.string(),
+  method: z.literal("eth_sendTransaction"),
+  attribution: z.boolean().optional(),
+  params: z.object({
+    abi: z.custom<Abi>(),
+    to: z.custom<`0x${string}`>(
+      (val): val is `0x${string}` =>
+        typeof val === "string" && val.startsWith("0x")
+    ),
+    value: z.string().optional(),
+    data: z
+      .custom<`0x${string}`>((val): val is `0x${string}` => typeof val === "string" && val.startsWith("0x"))
+      .optional(),
+  }),
+});
+
+export type EthSendTransactionAction = z.infer<
+  typeof ethSendTransactionActionSchema
+>;
+
+const ethSignTypedDataV4ActionSchema = z.object({
+  chainId: z.string(),
+  method: z.literal("eth_signTypedData_v4"),
+  params: z.object({
+    domain: z.custom<TypedDataDomain>(),
+    types: z.unknown(),
+    primaryType: z.string(),
+    message: z.record(z.unknown()),
+  }),
+});
+
+export type EthSignTypedDataV4Action = z.infer<
+  typeof ethSignTypedDataV4ActionSchema
+>;
+
+const walletActionRequestSchema = z.object({
+  jsonrpc: z.literal("2.0"),
+  id: z.string(),
+  method: z.literal("fc_requestWalletAction"),
+  params: z.object({
+    action: z.union([
+      ethSendTransactionActionSchema,
+      ethSignTypedDataV4ActionSchema,
+    ]),
+  }),
+});
+
+export type RequestWalletActionMessage = z.infer<
+  typeof walletActionRequestSchema
+>;
+
+export const miniAppMessageSchema = z.union([
+  createCastRequestSchemaLegacy,
+  walletActionRequestSchema,
+  createCastRequestSchema,
+]);
+
+export type MiniAppMessage = z.infer<typeof miniAppMessageSchema>;

--- a/packages/render/src/unstable-types.ts
+++ b/packages/render/src/unstable-types.ts
@@ -11,7 +11,10 @@ import type {
   ParseResultWithFrameworkDetails,
 } from "frames.js/frame-parsers";
 import type { Dispatch } from "react";
-import type { ErrorMessageResponse } from "frames.js/types";
+import type {
+  ComposerActionState,
+  ErrorMessageResponse,
+} from "frames.js/types";
 import type {
   ButtonPressFunction,
   FrameContext,
@@ -641,3 +644,32 @@ export type FrameState<
         TExtraMesssage
       >;
     };
+
+export type SignerStateComposerActionContext = {
+  fid: number;
+  url: string;
+  state: ComposerActionState;
+};
+
+export type SignerComposerActionResult = {
+  untrustedData: {
+    fid: number;
+    url: string;
+    messageHash: `0x${string}`;
+    timestamp: number;
+    network: number;
+    buttonIndex: 1;
+    state: string;
+  };
+  trustedData: {
+    messageBytes: string;
+  };
+};
+
+/**
+ * Used to sign composer action
+ */
+export type SignComposerActionFunc = (
+  signerPrivateKey: string,
+  actionContext: SignerStateComposerActionContext
+) => Promise<SignerComposerActionResult>;

--- a/packages/render/src/use-composer-action.ts
+++ b/packages/render/src/use-composer-action.ts
@@ -559,7 +559,12 @@ export function useComposerAction({
   }, [state, refetch]);
 }
 
-const defaultRegisterMessageListener: RegisterMessageListener =
+export { miniAppMessageSchema };
+
+/**
+ * Default function used to register message listener. Works in browsers only.
+ */
+export const defaultRegisterMessageListener: RegisterMessageListener =
   function defaultRegisterMessageListener(formResponse, messageListener) {
     if (typeof window === "undefined") {
       // eslint-disable-next-line no-console -- provide feedback

--- a/packages/render/src/use-composer-action.ts
+++ b/packages/render/src/use-composer-action.ts
@@ -70,7 +70,7 @@ export type OnCreateCastFunction = (arg: {
 
 export type ResolveAddressFunction = () => Promise<`0x${string}` | null>;
 
-export type OnPostMessageToTargetFunction = (
+export type OnMessageRespondFunction = (
   response: MiniAppResponse,
   form: ComposerActionFormResponse
 ) => unknown;
@@ -119,9 +119,9 @@ export type UseComposerActionOptions = {
   onTransaction: OnTransactionFunction;
   onSignature: OnSignatureFunction;
   /**
-   * Called when a response to a message is sent to target (e.g. iframe).
+   * Called with message response to be posted to child (e.g. iframe).
    */
-  onPostResponseToTarget: OnPostMessageToTargetFunction;
+  onMessageRespond: OnMessageRespondFunction;
   /**
    * Allows to override how the message listener is registered. Function must return a function that removes the listener.
    *
@@ -170,7 +170,7 @@ export function useComposerAction({
   onTransaction,
   resolveAddress,
   registerMessageListener = defaultRegisterMessageListener,
-  onPostResponseToTarget,
+  onMessageRespond,
 }: UseComposerActionOptions): UseComposerActionResult {
   const onErrorRef = useFreshRef(onError);
   const [state, dispatch] = useReducer(composerActionReducer, {
@@ -180,7 +180,7 @@ export function useComposerAction({
   const registerMessageListenerRef = useFreshRef(registerMessageListener);
   const actionStateRef = useFreshRef(actionState);
   const onCreateCastRef = useFreshRef(onCreateCast);
-  const onPostResponseToTargetRef = useFreshRef(onPostResponseToTarget);
+  const onMessageRespondRef = useFreshRef(onMessageRespond);
   const onTransactionRef = useFreshRef(onTransaction);
   const onSignatureRef = useFreshRef(onSignature);
   const resolveAddressRef = useFreshRef(resolveAddress);
@@ -206,7 +206,7 @@ export function useComposerAction({
         );
 
         if (resultOrError instanceof Error) {
-          onPostResponseToTargetRef.current(
+          onMessageRespondRef.current(
             {
               jsonrpc: "2.0",
               id: "method" in message ? message.id : null,
@@ -219,7 +219,7 @@ export function useComposerAction({
           );
         }
 
-        onPostResponseToTargetRef.current(
+        onMessageRespondRef.current(
           {
             jsonrpc: "2.0",
             id: "method" in message ? message.id : null,
@@ -237,7 +237,7 @@ export function useComposerAction({
         if (addressOrError instanceof Error) {
           tryCall(() => onErrorRef.current?.(addressOrError));
 
-          onPostResponseToTargetRef.current(
+          onMessageRespondRef.current(
             {
               jsonrpc: "2.0",
               id: message.id,
@@ -269,7 +269,7 @@ export function useComposerAction({
           if (resultOrError instanceof Error) {
             tryCall(() => onErrorRef.current?.(resultOrError));
 
-            onPostResponseToTargetRef.current(
+            onMessageRespondRef.current(
               {
                 jsonrpc: "2.0",
                 id: message.id,
@@ -289,7 +289,7 @@ export function useComposerAction({
 
             tryCall(() => onErrorRef.current?.(error));
 
-            onPostResponseToTargetRef.current(
+            onMessageRespondRef.current(
               {
                 jsonrpc: "2.0",
                 id: message.id,
@@ -303,7 +303,7 @@ export function useComposerAction({
             return;
           }
 
-          onPostResponseToTargetRef.current(
+          onMessageRespondRef.current(
             {
               jsonrpc: "2.0",
               id: message.id,
@@ -327,7 +327,7 @@ export function useComposerAction({
           if (resultOrError instanceof Error) {
             tryCall(() => onErrorRef.current?.(resultOrError));
 
-            onPostResponseToTargetRef.current(
+            onMessageRespondRef.current(
               {
                 jsonrpc: "2.0",
                 id: message.id,
@@ -347,7 +347,7 @@ export function useComposerAction({
 
             tryCall(() => onErrorRef.current?.(error));
 
-            onPostResponseToTargetRef.current(
+            onMessageRespondRef.current(
               {
                 jsonrpc: "2.0",
                 id: message.id,
@@ -362,7 +362,7 @@ export function useComposerAction({
             return;
           }
 
-          onPostResponseToTargetRef.current(
+          onMessageRespondRef.current(
             {
               jsonrpc: "2.0",
               id: message.id,
@@ -389,7 +389,7 @@ export function useComposerAction({
     [
       onCreateCastRef,
       onErrorRef,
-      onPostResponseToTargetRef,
+      onMessageRespondRef,
       onSignatureRef,
       onTransactionRef,
       resolveAddressRef,

--- a/packages/render/src/use-composer-action.ts
+++ b/packages/render/src/use-composer-action.ts
@@ -1,0 +1,613 @@
+import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
+import type {
+  ComposerActionFormResponse,
+  ComposerActionState,
+} from "frames.js/types";
+import type { FarcasterSignerState } from "./farcaster";
+import { useFreshRef } from "./hooks/use-fresh-ref";
+import {
+  isComposerFormActionResponse,
+  mergeSearchParamsToUrl,
+  tryCall,
+  tryCallAsync,
+} from "./helpers";
+import {
+  ComposerActionUnexpectedResponseError,
+  ComposerActionUserRejectedRequestError,
+} from "./errors";
+import type {
+  EthSendTransactionAction,
+  EthSignTypedDataV4Action,
+  MiniAppMessage,
+  MiniAppResponse,
+} from "./mini-app-messages";
+import { miniAppMessageSchema } from "./mini-app-messages";
+import type { FarcasterSigner } from "./identity/farcaster";
+
+export type { MiniAppMessage, MiniAppResponse };
+
+type FetchComposerActionFunctionArg = {
+  actionState: ComposerActionState;
+  proxyUrl: string;
+  signer: FarcasterSigner | null;
+  url: string;
+};
+
+type FetchComposerActionFunction = (
+  arg: FetchComposerActionFunctionArg
+) => Promise<void>;
+
+type RegisterMessageListener = (
+  formResponse: ComposerActionFormResponse,
+  messageListener: MiniAppMessageListener
+) => () => void;
+
+type MiniAppMessageListener = (message: MiniAppMessage) => Promise<void>;
+
+type OnTransactionFunction = (arg: {
+  action: EthSendTransactionAction;
+}) => Promise<{
+  hash: `0x${string}`;
+  address: `0x${string}`;
+} | null>;
+type OnSignatureFunction = (arg: {
+  action: EthSignTypedDataV4Action;
+}) => Promise<{
+  hash: `0x${string}`;
+  address: `0x${string}`;
+} | null>;
+type OnCreateCastFunction = (arg: {
+  cast: ComposerActionState;
+}) => Promise<void>;
+
+export type UseComposerActionOptions = {
+  /**
+   * Current action state, value should be memoized. It doesn't cause composer action / mini app to refetch.
+   */
+  actionState: ComposerActionState;
+  /**
+   * URL to composer action / mini app server
+   *
+   * If value changes it will refetch the composer action / mini app
+   */
+  url: string;
+  /**
+   * Signer used to sign the composer action.
+   *
+   * If value changes it will refetch the composer action / mini app
+   */
+  signer: FarcasterSignerState<any>;
+  /**
+   * URL to the action proxy server. If value changes composer action / mini app will be refetched.
+   *
+   * Proxy must handle POST requests.
+   */
+  proxyUrl: string;
+  /**
+   * If enabled if will fetch the composer action / mini app on mount.
+   *
+   * @defaultValue true
+   */
+  enabled?: boolean;
+  onError?: (error: Error) => void;
+  onCreateCast: OnCreateCastFunction;
+  onTransaction: OnTransactionFunction;
+  onSignature: OnSignatureFunction;
+  /**
+   * Called when a response to a message is sent to target (e.g. iframe).
+   */
+  onPostResponseToTarget: (response: MiniAppResponse) => unknown;
+  /**
+   * Allows to override how the message listener is registered. Function must return a function that removes the listener.
+   *
+   * Changes in the value aren't reflected so it's recommended to use a memoized function.
+   *
+   * By default it uses window.addEventListener("message", ...)
+   */
+  registerMessageListener?: RegisterMessageListener;
+};
+
+type UseComposerActionResult = {
+  refetch: () => Promise<void>;
+} & (
+  | {
+      status: "idle";
+      data: undefined;
+      error: undefined;
+    }
+  | {
+      status: "loading";
+      data: undefined;
+      error: undefined;
+    }
+  | {
+      status: "error";
+      data: undefined;
+      error: Error;
+    }
+  | {
+      status: "success";
+      data: ComposerActionFormResponse;
+      error: undefined;
+    }
+);
+
+export function useComposerAction({
+  actionState,
+  enabled = true,
+  proxyUrl,
+  signer,
+  url,
+  onError,
+  onCreateCast,
+  onSignature,
+  onTransaction,
+  registerMessageListener = defaultRegisterMessageListener,
+  onPostResponseToTarget,
+}: UseComposerActionOptions): UseComposerActionResult {
+  const onErrorRef = useFreshRef(onError);
+  const [state, dispatch] = useReducer(composerActionReducer, {
+    status: "idle",
+    enabled,
+  });
+  const registerMessageListenerRef = useFreshRef(registerMessageListener);
+  const actionStateRef = useFreshRef(actionState);
+  const onCreateCastRef = useFreshRef(onCreateCast);
+  const onPostResponseToTargetRef = useFreshRef(onPostResponseToTarget);
+  const onTransactionRef = useFreshRef(onTransaction);
+  const onSignatureRef = useFreshRef(onSignature);
+  const lastFetchActionArgRef = useRef<FetchComposerActionFunctionArg | null>(
+    null
+  );
+  const signerRef = useFreshRef(signer);
+
+  const messageListener = useCallback<MiniAppMessageListener>(
+    async (message) => {
+      if ("type" in message || message.method === "fc_createCast") {
+        const cast =
+          "type" in message ? message.data.cast : message.params.cast;
+
+        const resultOrError = await tryCallAsync(() =>
+          onCreateCastRef.current({
+            cast,
+          })
+        );
+
+        if (resultOrError instanceof Error) {
+          onPostResponseToTargetRef.current({
+            jsonrpc: "2.0",
+            id: "method" in message ? message.id : null,
+            error: {
+              code: -32000,
+              message: resultOrError.message,
+            },
+          });
+        }
+
+        onPostResponseToTargetRef.current({
+          jsonrpc: "2.0",
+          id: "method" in message ? message.id : null,
+          result: {
+            success: true,
+          },
+        });
+      } else if (message.method === "fc_requestWalletAction") {
+        if (message.params.action.method === "eth_sendTransaction") {
+          const action = message.params.action;
+
+          const resultOrError = await tryCallAsync(() =>
+            onTransactionRef.current({
+              action,
+            })
+          );
+
+          if (resultOrError instanceof Error) {
+            tryCall(() => onErrorRef.current?.(resultOrError));
+
+            onPostResponseToTargetRef.current({
+              jsonrpc: "2.0",
+              id: message.id,
+              error: {
+                code: -32000,
+                message: resultOrError.message,
+              },
+            });
+
+            return;
+          }
+
+          if (!resultOrError) {
+            const error = new ComposerActionUserRejectedRequestError();
+
+            tryCall(() => onErrorRef.current?.(error));
+
+            onPostResponseToTargetRef.current({
+              jsonrpc: "2.0",
+              id: message.id,
+              error: {
+                code: -32000,
+                message: error.message,
+              },
+            });
+            return;
+          }
+
+          onPostResponseToTargetRef.current({
+            jsonrpc: "2.0",
+            id: message.id,
+            result: {
+              address: resultOrError.address,
+              transactionHash: resultOrError.hash,
+            },
+          });
+        } else if (message.params.action.method === "eth_signTypedData_v4") {
+          const action = message.params.action;
+
+          const resultOrError = await tryCallAsync(() =>
+            onSignatureRef.current({
+              action,
+            })
+          );
+
+          if (resultOrError instanceof Error) {
+            tryCall(() => onErrorRef.current?.(resultOrError));
+
+            onPostResponseToTargetRef.current({
+              jsonrpc: "2.0",
+              id: message.id,
+              error: {
+                code: -32000,
+                message: resultOrError.message,
+              },
+            });
+
+            return;
+          }
+
+          if (!resultOrError) {
+            const error = new ComposerActionUserRejectedRequestError();
+
+            tryCall(() => onErrorRef.current?.(error));
+
+            onPostResponseToTargetRef.current({
+              jsonrpc: "2.0",
+              id: message.id,
+              error: {
+                code: -32000,
+                message: error.message,
+              },
+            });
+
+            return;
+          }
+
+          onPostResponseToTargetRef.current({
+            jsonrpc: "2.0",
+            id: message.id,
+            result: {
+              address: resultOrError.address,
+              signature: resultOrError.hash,
+            },
+          });
+        } else {
+          tryCall(() =>
+            onErrorRef.current?.(
+              new Error(
+                `Unknown fc_requestWalletAction action method: ${message.params.action.method}`
+              )
+            )
+          );
+        }
+      } else {
+        tryCall(() => onErrorRef.current?.(new Error("Unknown message")));
+      }
+    },
+    [
+      onCreateCastRef,
+      onErrorRef,
+      onPostResponseToTargetRef,
+      onSignatureRef,
+      onTransactionRef,
+    ]
+  );
+
+  const fetchAction = useCallback<FetchComposerActionFunction>(
+    async (arg) => {
+      const currentSigner = arg.signer;
+
+      if (
+        currentSigner?.status !== "approved" &&
+        currentSigner?.status !== "impersonating"
+      ) {
+        await signerRef.current.onSignerlessFramePress();
+        return;
+      }
+
+      dispatch({ type: "loading-url" });
+
+      const signedDataOrError = await tryCallAsync(() =>
+        signerRef.current.signComposerAction(currentSigner.privateKey, {
+          url: arg.url,
+          state: arg.actionState,
+          fid: currentSigner.fid,
+        })
+      );
+
+      if (signedDataOrError instanceof Error) {
+        tryCall(() => onErrorRef.current?.(signedDataOrError));
+        dispatch({ type: "error", error: signedDataOrError });
+
+        return;
+      }
+
+      const proxiedUrl = mergeSearchParamsToUrl(
+        arg.proxyUrl,
+        new URLSearchParams({ postUrl: arg.url })
+      );
+
+      const actionResponseOrError = await tryCallAsync(() =>
+        fetch(proxiedUrl, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(signedDataOrError),
+          cache: "no-cache",
+        })
+      );
+
+      if (actionResponseOrError instanceof Error) {
+        tryCall(() => onErrorRef.current?.(actionResponseOrError));
+        dispatch({ type: "error", error: actionResponseOrError });
+
+        return;
+      }
+
+      if (!actionResponseOrError.ok) {
+        const error = new Error(
+          `Unexpected response status ${actionResponseOrError.status}`
+        );
+
+        tryCall(() => onErrorRef.current?.(error));
+        dispatch({ type: "error", error });
+
+        return;
+      }
+
+      const actionResponseDataOrError = await tryCallAsync(
+        () => actionResponseOrError.clone().json() as Promise<unknown>
+      );
+
+      if (actionResponseDataOrError instanceof Error) {
+        tryCall(() => onErrorRef.current?.(actionResponseDataOrError));
+        dispatch({ type: "error", error: actionResponseDataOrError });
+
+        return;
+      }
+
+      if (!isComposerFormActionResponse(actionResponseDataOrError)) {
+        const error = new ComposerActionUnexpectedResponseError();
+        tryCall(() => onErrorRef.current?.(error));
+        dispatch({ type: "error", error });
+
+        return;
+      }
+
+      dispatch({ type: "done", response: actionResponseDataOrError });
+    },
+    [onErrorRef]
+  );
+
+  const stateRef = useFreshRef(state);
+  const refetch = useCallback(() => {
+    if (!stateRef.current.enabled || !lastFetchActionArgRef.current) {
+      return Promise.resolve();
+    }
+
+    return fetchAction(lastFetchActionArgRef.current);
+  }, [fetchAction, stateRef]);
+
+  useEffect(() => {
+    dispatch({ type: "enabled-change", enabled });
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    lastFetchActionArgRef.current = {
+      actionState: actionStateRef.current,
+      signer: signer.signer as unknown as FarcasterSigner | null,
+      url,
+      proxyUrl,
+    };
+
+    fetchAction(lastFetchActionArgRef.current).catch((e) => {
+      onErrorRef.current?.(e instanceof Error ? e : new Error(String(e)));
+    });
+  }, [
+    url,
+    proxyUrl,
+    signer.signer,
+    enabled,
+    fetchAction,
+    actionStateRef,
+    onErrorRef,
+  ]);
+
+  // register message listener when state changes to success
+  useEffect(() => {
+    if (state.status === "success") {
+      return registerMessageListenerRef.current(
+        state.response,
+        messageListener
+      );
+    }
+  }, [messageListener, registerMessageListenerRef, state]);
+
+  return useMemo(() => {
+    switch (state.status) {
+      case "idle":
+        return {
+          status: "idle",
+          data: undefined,
+          error: undefined,
+          refetch,
+        };
+      case "loading":
+        return {
+          status: "loading",
+          data: undefined,
+          error: undefined,
+          refetch,
+        };
+      case "error":
+        return {
+          status: "error",
+          data: undefined,
+          error: state.error,
+          refetch,
+        };
+      default:
+        return {
+          status: "success",
+          data: state.response,
+          error: undefined,
+          refetch,
+        };
+    }
+  }, [state, refetch]);
+}
+
+const defaultRegisterMessageListener: RegisterMessageListener =
+  function defaultRegisterMessageListener(formResponse, messageListener) {
+    if (typeof window === "undefined") {
+      // eslint-disable-next-line no-console -- provide feedback
+      console.warn(
+        "@frames.js/render: You are using default registerMessageListener in an environment without window object"
+      );
+
+      return () => {
+        // noop
+      };
+    }
+
+    const miniAppOrigin = new URL(formResponse.url).origin;
+
+    const messageParserListener = (event: MessageEvent): void => {
+      // make sure that we only listen to messages from the mini app
+      if (event.origin !== miniAppOrigin) {
+        return;
+      }
+
+      const result = miniAppMessageSchema.safeParse(event.data);
+
+      if (!result.success) {
+        // eslint-disable-next-line no-console -- provide feedback
+        console.warn(
+          "@frames.js/render: Invalid message received",
+          event.data,
+          result.error
+        );
+        return;
+      }
+
+      const message = result.data;
+
+      messageListener(message).catch((e) => {
+        // eslint-disable-next-line no-console -- provide feedback
+        console.error(`@frames.js/render:`, e);
+      });
+    };
+
+    window.addEventListener("message", messageParserListener);
+
+    return () => {
+      window.removeEventListener("message", messageParserListener);
+    };
+  };
+
+type SharedComposerActionReducerState = {
+  enabled: boolean;
+};
+
+type ComposerActionReducerState = SharedComposerActionReducerState &
+  (
+    | {
+        status: "idle";
+      }
+    | {
+        status: "loading";
+      }
+    | {
+        status: "error";
+        error: Error;
+      }
+    | {
+        status: "success";
+        response: ComposerActionFormResponse;
+      }
+  );
+
+type ComposerActionReducerAction =
+  | {
+      type: "loading-url";
+    }
+  | {
+      type: "error";
+      error: Error;
+    }
+  | {
+      type: "done";
+      response: ComposerActionFormResponse;
+    }
+  | {
+      type: "enabled-change";
+      enabled: boolean;
+    };
+
+function composerActionReducer(
+  state: ComposerActionReducerState,
+  action: ComposerActionReducerAction
+): ComposerActionReducerState {
+  if (action.type === "enabled-change") {
+    if (action.enabled) {
+      return {
+        ...state,
+        enabled: true,
+      };
+    }
+
+    return {
+      status: "idle",
+      enabled: false,
+    };
+  }
+
+  if (!state.enabled) {
+    return state;
+  }
+
+  switch (action.type) {
+    case "done":
+      return {
+        ...state,
+        status: "success",
+        response: action.response,
+      };
+    case "loading-url":
+      return {
+        ...state,
+        status: "loading",
+      };
+    case "error":
+      return {
+        ...state,
+        status: "error",
+        error: action.error,
+      };
+    default:
+      return state;
+  }
+}

--- a/packages/render/src/use-composer-action.ts
+++ b/packages/render/src/use-composer-action.ts
@@ -105,6 +105,10 @@ export type UseComposerActionOptions = {
    */
   enabled?: boolean;
   /**
+   * Custom fetch function to fetch the composer action / mini app.
+   */
+  fetch?: (url: string, init: RequestInit) => Promise<Response>;
+  /**
    * Called before onTransaction/onSignature is invoked to obtain an address to use.
    *
    * If the function returns null onTransaction/onSignature will not be called.
@@ -159,6 +163,7 @@ export function useComposerAction({
   proxyUrl,
   signer,
   url,
+  fetch: fetchFunction,
   onError,
   onCreateCast,
   onSignature,
@@ -183,6 +188,7 @@ export function useComposerAction({
     null
   );
   const signerRef = useFreshRef(signer);
+  const fetchRef = useFreshRef(fetchFunction);
 
   const messageListener = useCallback(
     async (
@@ -425,7 +431,7 @@ export function useComposerAction({
       );
 
       const actionResponseOrError = await tryCallAsync(() =>
-        fetch(proxiedUrl, {
+        (fetchRef.current || fetch)(proxiedUrl, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -474,7 +480,7 @@ export function useComposerAction({
 
       dispatch({ type: "done", response: actionResponseDataOrError });
     },
-    [onErrorRef, signerRef]
+    [fetchRef, onErrorRef, signerRef]
   );
 
   const stateRef = useFreshRef(state);


### PR DESCRIPTION
## Change Summary

This PR adds new `useComposerAction()` hook to simplify building mini apps.

## TODO

- [x] - implement the hook
- [x] - implement transactions in debugger
- [ ] - decide a name for `useComposerAction()` hook

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
