### PR TITLE
chore: use resolveAddress instead of connectedAddress

### DIFF
--- a/packages/debugger/app/components/cast-composer.tsx
+++ b/packages/debugger/app/components/cast-composer.tsx
@@ -137,7 +137,9 @@ function CastEmbedPreview({ onRemove, url }: CastEmbedPreviewProps) {
   const farcasterIdentity = useFarcasterIdentity();
   const frame = useFrame_unstable({
     frameStateHook: useDebuggerFrameState,
-    connectedAddress: account.address,
+    async resolveAddress() {
+      return account.address ?? null;
+    },
     homeframeUrl: url,
     frameActionProxy: "/frames",
     frameGetProxy: "/frames",

--- a/packages/render/src/unstable-types.ts
+++ b/packages/render/src/unstable-types.ts
@@ -21,7 +21,6 @@ import type {
   FrameGETRequest,
   FramePOSTRequest,
   FrameRequest,
-  OnConnectWalletFunc,
   OnMintArgs,
   OnSignatureFunc,
   OnTransactionFunc,
@@ -48,6 +47,8 @@ export type ResolveSignerFunctionArg = {
 export type ResolveSignerFunction = (
   arg: ResolveSignerFunctionArg
 ) => ResolvedSigner;
+
+export type ResolveAddressFunction = () => Promise<`0x${string}` | null>;
 
 export type UseFrameOptions<
   TExtraDataPending = unknown,
@@ -103,9 +104,13 @@ export type UseFrameOptions<
    */
   frame?: ParseFramesWithReportsResult | null;
   /**
-   * connected wallet address of the user, send to the frame for transaction requests
+   * Called before onTransaction/onSignature is invoked to obtain an address to use.
+   *
+   * If the function returns null onTransaction/onSignature will not be called.
+   *
+   * Sent to the frame on transaction requests.
    */
-  connectedAddress: `0x${string}` | undefined;
+  resolveAddress: ResolveAddressFunction;
   /** a function to handle mint buttons */
   onMint?: (t: OnMintArgs) => void;
   /** a function to handle transaction buttons that returned transaction data from the target, returns the transaction hash or null */
@@ -114,10 +119,6 @@ export type UseFrameOptions<
   transactionDataSuffix?: `0x${string}`;
   /** A function to handle transaction buttons that returned signature data from the target, returns signature hash or null */
   onSignature?: OnSignatureFunc;
-  /**
-   * Called when user presses transaction button but there is no wallet connected.
-   */
-  onConnectWallet?: OnConnectWalletFunc;
   /**
    * Extra data appended to the frame action payload
    */

--- a/packages/render/src/use-composer-action.ts
+++ b/packages/render/src/use-composer-action.ts
@@ -23,8 +23,9 @@ import type {
 } from "./mini-app-messages";
 import { miniAppMessageSchema } from "./mini-app-messages";
 import type { FarcasterSigner } from "./identity/farcaster";
+import type { ResolveAddressFunction } from "./unstable-types";
 
-export type { MiniAppMessage, MiniAppResponse };
+export type { MiniAppMessage, MiniAppResponse, ResolveAddressFunction };
 
 type FetchComposerActionFunctionArg = {
   actionState: ComposerActionState;
@@ -67,8 +68,6 @@ export type OnSignatureFunction = (arg: {
 export type OnCreateCastFunction = (arg: {
   cast: ComposerActionState;
 }) => Promise<void>;
-
-export type ResolveAddressFunction = () => Promise<`0x${string}` | null>;
 
 export type OnMessageRespondFunction = (
   response: MiniAppResponse,


### PR DESCRIPTION
## Change Summary

This PR replaces `onConnectWallet` and `connectedAdress` with `resolveAddress` on `useFrame_unstable()` hook.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [ ] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
