### PR TITLE
fix: export missing type from anonymous identity hook

### DIFF
--- a/.changeset/old-pumas-call.md
+++ b/.changeset/old-pumas-call.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/render": patch
+---
+
+fix(@frames.js/render): export missing type for anonymous signer

--- a/packages/render/src/identity/anonymous/index.ts
+++ b/packages/render/src/identity/anonymous/index.ts
@@ -1,5 +1,6 @@
 export {
   type AnonymousFrameContext,
   type AnonymousSigner,
+  type AnonymousSignerInstance,
   useAnonymousIdentity,
 } from "./use-anonymous-identity";


### PR DESCRIPTION
## Change Summary

This PR adds missing export for `AnonymousSignerInstance` type.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
