### PR TITLE
fix: a "complete" URLObject in `target` should be left as it is

### DIFF
--- a/.changeset/mighty-mugs-refuse.md
+++ b/.changeset/mighty-mugs-refuse.md
@@ -1,0 +1,5 @@
+---
+"frames.js": patch
+---
+
+fix: a "complete" URLObject in `target` should be left as it is

--- a/packages/frames.js/src/core/utils.test.ts
+++ b/packages/frames.js/src/core/utils.test.ts
@@ -41,6 +41,18 @@ describe("generateTargetURL", () => {
       "http://test.com/test?test=test"
     );
   });
+
+  it("generates a correct URL if target is an URL object with every compulsory property", () => {
+    // If the user passing in a URL object with all props required to 
+    // construct a full URL, that means they want to go straight to 
+    // there without modification.
+    const baseUrl = new URL("http://test.com");
+    const target = new URL("http://another.com/test");
+
+    expect(generateTargetURL({ baseUrl, target }).toString()).toBe(
+      target.toString()
+    );
+  });
 });
 
 describe("resolveBaseUrl", () => {

--- a/packages/frames.js/src/core/utils.ts
+++ b/packages/frames.js/src/core/utils.ts
@@ -49,9 +49,9 @@ function isValidButtonAction(action: unknown): action is ButtonActions {
 
 function isUrlObjectComplete(urlObject: UrlObject): boolean {
   return (
-    "host" in urlObject &&
-    "protocol" in urlObject &&
-    "pathname" in urlObject
+    !!urlObject.host &&
+    !!urlObject.protocol &&
+    !!urlObject.pathname
   );
 }
 

--- a/packages/frames.js/src/core/utils.ts
+++ b/packages/frames.js/src/core/utils.ts
@@ -47,6 +47,14 @@ function isValidButtonAction(action: unknown): action is ButtonActions {
   return typeof action === "string" && action in buttonActionToCode;
 }
 
+function isUrlObjectComplete(urlObject: UrlObject): boolean {
+  return (
+    "host" in urlObject &&
+    "protocol" in urlObject &&
+    "pathname" in urlObject
+  );
+}
+
 export function generateTargetURL({
   baseUrl,
   target,
@@ -59,6 +67,9 @@ export function generateTargetURL({
   }
 
   if (typeof target === "object") {
+    if (isUrlObjectComplete(target)) {
+      return new URL(formatUrl(target));
+    }
     return new URL(
       formatUrl({
         host: baseUrl.host,


### PR DESCRIPTION

## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->
This PR avoids pathname overwriting when passing in an URLObject with all necessary props to `generateTargetURL()`.

If the user passing in a URL object with all props required to construct a full URL, that means they want to go straight to there without modification. But current behaviour of `generateTargetURL()` overwrite its `pathname` by prepending the `pathname` of `baseUrl`

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
