### PR TITLE
fix: pass original frame app url to view

### DIFF
--- a/.changeset/slow-pigs-hug.md
+++ b/.changeset/slow-pigs-hug.md
@@ -1,0 +1,5 @@
+---
+"@frames.js/render": patch
+---
+
+fix: pass original frame app source url to view

--- a/packages/render/src/frame-app/iframe.ts
+++ b/packages/render/src/frame-app/iframe.ts
@@ -105,17 +105,7 @@ export function useFrameAppInIframe(
       case "pending":
         return frameApp;
       case "success": {
-        const frameUrl = frameApp.frame.frame.button?.action?.url;
-
-        if (!frameUrl) {
-          return {
-            status: "error",
-            error: new Error(
-              "Frame URL is not provided, please check button.action.url"
-            ),
-          };
-        }
-
+        const frameUrl = frameApp.frameUrl.toString();
         const frameOrigin = new URL(frameUrl).origin;
 
         return {

--- a/packages/render/src/frame-app/web-view.ts
+++ b/packages/render/src/frame-app/web-view.ts
@@ -120,17 +120,7 @@ export function useFrameAppInWebView(
       case "pending":
         return frameApp;
       case "success": {
-        const frame = frameApp.frame.frame;
-        const frameUrl = frame.button?.action?.url;
-
-        if (!frameUrl) {
-          return {
-            status: "error",
-            error: new Error(
-              "Frame URL is not provided, please check button.action.url"
-            ),
-          };
-        }
+        const frameUrl = frameApp.frameUrl.toString();
 
         return {
           ...frameApp,

--- a/packages/render/src/use-frame-app.ts
+++ b/packages/render/src/use-frame-app.ts
@@ -208,7 +208,7 @@ export type UseFrameAppReturn =
       /**
        * Url that has been used to fetch the frame app.
        *
-       * If the source was set to parse result object, this will contain url of the frame from manifest.
+       * If the source was set to parse result object, this will contain url of the frame's button action definition.
        */
       frameUrl: URL;
       status: "success";

--- a/packages/render/src/use-frame-app.ts
+++ b/packages/render/src/use-frame-app.ts
@@ -205,6 +205,12 @@ export type UseFrameAppReturn =
   | {
       frame: ParseFramesV2ResultWithFrameworkDetails;
       client: FrameClientConfig;
+      /**
+       * Url that has been used to fetch the frame app.
+       *
+       * If the source was set to parse result object, this will contain url of the frame from manifest.
+       */
+      frameUrl: URL;
       status: "success";
       /**
        * Creates sdk that must be exposed to frame app endpoint
@@ -302,6 +308,22 @@ export function useFrameApp({
     switch (frameResolutionState.status) {
       case "success": {
         const frame = frameResolutionState.frame;
+        let frameUrl: URL;
+
+        if (frameResolutionState.source instanceof URL) {
+          frameUrl = frameResolutionState.source;
+        } else if (typeof frameResolutionState.source === "string") {
+          frameUrl = new URL(frameResolutionState.source);
+        } else if (frame.frame.button?.action?.url) {
+          frameUrl = new URL(frame.frame.button.action.url);
+        } else {
+          return {
+            status: "error",
+            error: new Error(
+              "Frame URL is not provided, please check button.action.url"
+            ),
+          };
+        }
 
         return {
           getEmitter: (endpoint) => ({
@@ -416,6 +438,7 @@ export function useFrameApp({
           }),
           status: "success",
           frame: frameResolutionState.frame,
+          frameUrl,
           client: clientResolutionState.client,
         };
       }


### PR DESCRIPTION
## Change Summary

This PR removes forcing frame app url to be `frame.button.action.url` and instead it uses the URL you used to fetch the frame data.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [x] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
