### PR TITLE
feat: simpler frame app context resolving

### DIFF
--- a/.changeset/fuzzy-cherries-mate.md
+++ b/.changeset/fuzzy-cherries-mate.md
@@ -1,0 +1,6 @@
+---
+"@frames.js/debugger": patch
+"@frames.js/render": patch
+---
+
+feat: simpler frame app context resolution

--- a/packages/debugger/app/notifications/types.ts
+++ b/packages/debugger/app/notifications/types.ts
@@ -2,7 +2,6 @@ import type {
   FrameNotificationDetails,
   SendNotificationRequest,
 } from "@farcaster/frame-sdk";
-import { FrameClientConfig } from "@frames.js/render/frame-app/types";
 import type { FrameServerEvent } from "frames.js/farcaster-v2/events";
 
 export type Notification = SendNotificationRequest;
@@ -40,7 +39,7 @@ export type RecordedEvent =
 export type NotificationSettings =
   | {
       enabled: true;
-      details: NonNullable<FrameClientConfig["notificationDetails"]>;
+      details: FrameNotificationDetails;
       webhookUrl: string;
       signerPrivateKey: string;
     }

--- a/packages/render/src/frame-app/types.ts
+++ b/packages/render/src/frame-app/types.ts
@@ -10,8 +10,6 @@ import type { ParseFramesV2ResultWithFrameworkDetails } from "frames.js/frame-pa
 import type { Provider } from "ox/Provider";
 import type { Default as DefaultRpcSchema, ExtractRequest } from "ox/RpcSchema";
 
-export type FrameClientConfig = Context.ClientContext;
-
 export type SendTransactionRpcRequest = ExtractRequest<
   DefaultRpcSchema,
   "eth_sendTransaction"
@@ -99,12 +97,21 @@ export type OnSignInFunction = (
 
 export type OnViewProfileFunction = FrameHost["viewProfile"];
 
-/**
- * Function called when the frame app is being loaded and we need to resolve the client that renders the frame app
- */
-export type ResolveClientFunction = (options: {
+export type FrameContext = Context.FrameContext;
+
+export type ResolveContextFunctionOptions = {
+  /**
+   * Called when hook is unmounted
+   */
   signal: AbortSignal;
-}) => Promise<FrameClientConfig>;
+};
+
+/**
+ * Function called when the frame app is loaded and needs a context to be rendered
+ */
+export type ResolveContextFunction = (
+  options: ResolveContextFunctionOptions
+) => Promise<FrameContext>;
 
 export type HostEndpointEmitter = Pick<
   HostEndpoint,


### PR DESCRIPTION
## Change Summary

This PR simplifies how context is set up for `useFrameApp()`. Now it uses only one property `context` instead of 3 and the context can be either an object or a function returning an object.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
