### PR TITLE
chore: handle `InvalidJFSHeaderError` in `parseManifest`

### DIFF
--- a/.changeset/little-berries-hang.md
+++ b/.changeset/little-berries-hang.md
@@ -1,0 +1,5 @@
+---
+"frames.js": minor
+---
+
+Handle `InvalidJFSHeaderError` in `parseManifest` for better error reporting

--- a/packages/frames.js/src/frame-parsers/farcasterV2.ts
+++ b/packages/frames.js/src/frame-parsers/farcasterV2.ts
@@ -5,7 +5,7 @@ import {
 } from "@farcaster/frame-core";
 import { z } from "zod";
 import type { FarcasterManifest } from "../farcaster-v2/types";
-import { decodePayload, verify } from "../farcaster-v2/json-signature";
+import { decodePayload, verify, InvalidJFSHeaderError } from "../farcaster-v2/json-signature";
 import { getMetaTag, removeInvalidDataFromObject } from "./utils";
 import type {
   ParseResultFramesV2,
@@ -331,7 +331,12 @@ async function parseManifest(
       reports: reporter.toObject(),
     };
   } catch (e) {
-    if (e instanceof Error) {
+    if(e instanceof InvalidJFSHeaderError) {
+      reporter.error(
+        "fc:manifest",
+        `Failed to verify account association signature: InvalidJFSHeaderError`
+      );
+    } else if (e instanceof Error) {
       reporter.error(
         "fc:manifest",
         `Failed to parse frame manifest: ${String(e)}`


### PR DESCRIPTION
## Change Summary

In the case of `InvalidJFSHeaderError`, the error is not detected in the debugger and you just see the following image:

![image](https://github.com/user-attachments/assets/b876d5cb-1d0c-4e3c-b471-eab2cf5b0561)

This change will catch this specific error for better DX.

Example using the command line:

**Without any change:**

![image](https://github.com/user-attachments/assets/186dee1d-c816-441c-a6b0-3027e8e91eda)

**Including the change**

![image](https://github.com/user-attachments/assets/fc5e3b01-38b3-4df6-af99-8f90da483fec)


## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a [Changeset](CONTRIBUTING.md)
- [ ] PR includes documentation if necessary
- [ ] PR updates the boilerplates if necessary
